### PR TITLE
helloworld go-client on mac can not be built, as when a new shell pro…

### DIFF
--- a/helloworld/dubbo/go-client/assembly/mac/dev.sh
+++ b/helloworld/dubbo/go-client/assembly/mac/dev.sh
@@ -32,5 +32,5 @@ fi
 
 
 if [ -f "${PROJECT_HOME}/assembly/common/build.sh" ]; then
-	sh ${PROJECT_HOME}/assembly/common/build.sh
+	. ${PROJECT_HOME}/assembly/common/build.sh
 fi

--- a/helloworld/dubbo/go-client/assembly/mac/release.sh
+++ b/helloworld/dubbo/go-client/assembly/mac/release.sh
@@ -30,5 +30,5 @@ if [ -f "${PROJECT_HOME}/assembly/common/app.properties" ]; then
 fi
 
 if [ -f "${PROJECT_HOME}/assembly/common/build.sh" ]; then
-  sh ${PROJECT_HOME}/assembly/common/build.sh
+  . ${PROJECT_HOME}/assembly/common/build.sh
 fi

--- a/helloworld/dubbo/go-client/assembly/mac/test.sh
+++ b/helloworld/dubbo/go-client/assembly/mac/test.sh
@@ -30,5 +30,5 @@ fi
 
 
 if [ -f "${PROJECT_HOME}/assembly/common/build.sh" ]; then
-  sh ${PROJECT_HOME}/assembly/common/build.sh
+  . ${PROJECT_HOME}/assembly/common/build.sh
 fi


### PR DESCRIPTION
helloworld go-client can not be built on mac:

```
zhu@Mac-mini go-client % sh ./assembly/mac/dev.sh
go: cannot find main module; see 'go help modules'
mv: rename /Users/bzhu/dubbo-go-samples/helloworld/dubbo/go-client/target/darwin/ to /Users/bzhu/dubbo-go-samples/helloworld/dubbo/go-client/target/darwin/-2.7.5-20201129-2345-dev/sbin/darwin/: Invalid argument
cp: assembly/bin: No such file or directory
sed: /Users/bzhu/dubbo-go-samples/helloworld/dubbo/go-client/target/darwin/-2.7.5-20201129-2345-dev/bin/*: No such file or directory
sed: /Users/bzhu/dubbo-go-samples/helloworld/dubbo/go-client/target/darwin/-2.7.5-20201129-2345-dev/bin/*: No such file or directory
sed: /Users/bzhu/dubbo-go-samples/helloworld/dubbo/go-client/target/darwin/-2.7.5-20201129-2345-dev/bin/*: No such file or directory
cp: profiles/dev/*: No such file or directory
Usage:
  List:    tar -tf <archive-filename>
  Extract: tar -xf <archive-filename>
  Create:  tar -cf <archive-filename> [filenames...]
  Help:    tar --help
```