### PR TITLE
fix: add provide_by to etcd go-server/client.yaml

### DIFF
--- a/registry/servicediscovery/etcd/go-server/conf/client.yml
+++ b/registry/servicediscovery/etcd/go-server/conf/client.yml
@@ -9,7 +9,7 @@ connect_timeout: "3s"
 # application config
 application:
   organization: "dubbo.io"
-  name: "UserInfoTest"
+  name: "UserInfoConsumer"
   module: "dubbo-go user-info client"
   version: "0.0.1"
   environment: "dev"
@@ -42,6 +42,7 @@ references:
   "UserProvider":
     registry: "demoServiceDiscovery"
     protocol: "dubbo"
+    provide_by: "UserInfoServer"
     interface: "org.apache.dubbo.UserProvider"
     cluster: "failover"
     methods:


### PR DESCRIPTION
Add provide_by: "UserInfoServer"
Only in this way can consumer find target provider.