### PR TITLE
Fix: UserProvider is not registered

### DIFF
--- a/general/jsonrpc/go-client/pkg/user.go
+++ b/general/jsonrpc/go-client/pkg/user.go
@@ -23,12 +23,6 @@ import (
 	"time"
 )
 
-import (
-	"dubbo.apache.org/dubbo-go/v3/config"
-)
-
-
-
 type JsonRPCUser struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`

--- a/general/jsonrpc/go-server/cmd/server.go
+++ b/general/jsonrpc/go-server/cmd/server.go
@@ -39,6 +39,10 @@ import (
 	_ "dubbo.apache.org/dubbo-go/v3/registry/zookeeper"
 )
 
+import (
+	_ "github.com/apache/dubbo-go-samples/general/jsonrpc/go-server/pkg"
+)
+
 var (
 	survivalTimeout = int(3e9)
 )


### PR DESCRIPTION
We need to import `github.com/apache/dubbo-go-samples/general/jsonrpc/go-server/pkg` to execute `init()`