### PR TITLE
Ftr: 3.0 lumberjack log sample

### DIFF
--- a/.run/logger-client.run.xml
+++ b/.run/logger-client.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="logger-client" type="GoApplicationRunConfiguration" factoryName="Go Application" singleton="false">
+        <module name="dubbo-go-samples" />
+        <working_directory value="$PROJECT_DIR$" />
+        <envs>
+            <env name="APP_LOG_CONF_FILE" value="$PROJECT_DIR$/logger/go-client/conf/log.yml" />
+            <env name="CONF_CONSUMER_FILE_PATH" value="$PROJECT_DIR$/logger/go-client/conf/client.yml" />
+        </envs>
+        <kind value="PACKAGE" />
+        <filePath value="$PROJECT_DIR$/logger/go-client/cmd/client.go" />
+        <package value="github.com/apache/dubbo-go-samples/logger/go-client/cmd" />
+        <directory value="$PROJECT_DIR$" />
+        <method v="2" />
+    </configuration>
+</component>

--- a/.run/logger-server.run.xml
+++ b/.run/logger-server.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="logger-server" type="GoApplicationRunConfiguration" factoryName="Go Application" singleton="false">
+        <module name="dubbo-go-samples" />
+        <working_directory value="$PROJECT_DIR$" />
+        <envs>
+            <env name="APP_LOG_CONF_FILE" value="$PROJECT_DIR$/logger/go-server/conf/log.yml" />
+            <env name="CONF_PROVIDER_FILE_PATH" value="$PROJECT_DIR$/logger/go-server/conf/server.yml" />
+        </envs>
+        <kind value="PACKAGE" />
+        <filePath value="$PROJECT_DIR$/logger/go-server/cmd/server.go" />
+        <package value="github.com/apache/dubbo-go-samples/logger/go-server/cmd" />
+        <directory value="$PROJECT_DIR$" />
+        <method v="2" />
+    </configuration>
+</component>

--- a/.run/tracing-dubbo-go-client.run.xml
+++ b/.run/tracing-dubbo-go-client.run.xml
@@ -3,8 +3,8 @@
     <module name="dubbo-go-samples" />
     <working_directory value="$PROJECT_DIR$" />
     <envs>
-      <env name="APP_LOG_CONF_FILE" value="$PROJECT_DIR$/tracing/dubbo/go-client/conf/log.yml" />
-      <env name="CONF_CONSUMER_FILE_PATH" value="$PROJECT_DIR$/tracing/dubbo/go-client/conf/client.yml" />
+      <env name="APP_LOG_CONF_FILE" value="$PROJECT_DIR$/tracing/dubbo/go-client/profiles/dev/log.yml" />
+      <env name="CONF_CONSUMER_FILE_PATH" value="$PROJECT_DIR$/tracing/dubbo/go-client/profiles/dev/client.yml" />
     </envs>
     <kind value="PACKAGE" />
     <filePath value="$PROJECT_DIR$/tracing/dubbo/go-client/cmd/client.go" />

--- a/.run/tracing-dubbo-go-server.run.xml
+++ b/.run/tracing-dubbo-go-server.run.xml
@@ -3,8 +3,8 @@
     <module name="dubbo-go-samples" />
     <working_directory value="$PROJECT_DIR$" />
     <envs>
-      <env name="CONF_PROVIDER_FILE_PATH" value="$PROJECT_DIR$/tracing/dubbo/go-server/conf/server.yml" />
-      <env name="APP_LOG_CONF_FILE" value="$PROJECT_DIR$/tracing/dubbo/go-server/conf/log.yml" />
+      <env name="CONF_PROVIDER_FILE_PATH" value="$PROJECT_DIR$/tracing/dubbo/go-server/profiles/dev/server.yml" />
+      <env name="APP_LOG_CONF_FILE" value="$PROJECT_DIR$/tracing/dubbo/go-server/profiles/dev/log.yml" />
     </envs>
     <kind value="PACKAGE" />
     <filePath value="$PROJECT_DIR$/tracing/dubbo/go-server/cmd/server.go" />

--- a/logger/README.md
+++ b/logger/README.md
@@ -1,0 +1,116 @@
+## Log usage
+
+The samples demonstrate how to configure dubbo-go logger using lumberjack
+
+### Configuration
+
+Output file settings
+
+```yaml
+lumberjackConfig:
+  # The name of the log file
+  filename: "logs.log"
+  # The maximum size of each log file length, the default is 100M
+  maxSize: 1
+  # Maximum number of days to keep logs (only keep the logs of the most recent days)
+  maxAge: 3
+  # Only keep the most recent log files, used to control the size of the total log of the program
+  maxBackups: 5
+  # Whether to use local time, UTC time is used by default
+  localTime: true
+  # Whether to compress the log file, the compression method is gzip
+  compress: false
+```
+
+Log format and level settings
+
+```yaml
+zapConfig:
+  level: "debug"
+  development: false
+  disableCaller: false
+  disableStacktrace: false
+  sampling:
+  encoding: "console"
+
+  # encoder
+  encoderConfig:
+    messageKey: "message"
+    levelKey: "level"
+    timeKey: "time"
+    nameKey: "logger"
+    callerKey: "caller"
+    stacktraceKey: "stacktrace"
+    lineEnding: ""
+    levelEncoder: "capitalColor"
+    timeEncoder: "iso8601"
+    durationEncoder: "seconds"
+    callerEncoder: "short"
+    nameEncoder: ""
+
+  outputPaths:
+    - "stderr"
+  errorOutputPaths:
+    - "stderr"
+  initialFields:
+```
+
+If you do not want to output to a file, you can follow the rules below to set only zap
+
+```yaml
+  level: "debug"
+  development: false
+  disableCaller: false
+  disableStacktrace: false
+  sampling:
+  encoding: "console"
+
+  # encoder
+  encoderConfig:
+    messageKey: "message"
+    levelKey: "level"
+    timeKey: "time"
+    nameKey: "logger"
+    callerKey: "caller"
+    stacktraceKey: "stacktrace"
+    lineEnding: ""
+    levelEncoder: "capitalColor"
+    timeEncoder: "iso8601"
+    durationEncoder: "seconds"
+    callerEncoder: "short"
+    nameEncoder: ""
+
+  outputPaths:
+    - "stderr"
+  errorOutputPaths:
+    - "stderr"
+  initialFields:
+```
+
+### Run
+
+A cycle of 1000000 times is set on the go-client side, and the server will be called all the time to facilitate the viewing of the log output
+
+```go
+func main() {
+	config.Load()
+	time.Sleep(3 * time.Second)
+
+	for i := 0;i < 1000000; i ++ {
+		test()
+	}
+
+}
+
+func test() {
+	logger.Info("\n\n\nstart to test dubbo")
+	user := &pkg.User{}
+	err := userProvider.GetUser(context.TODO(), []interface{}{"A001"}, user)
+	if err != nil {
+		logger.Infof("error: %v\n", err)
+		os.Exit(1)
+		return
+	}
+	logger.Infof("response result: %v\n", user)
+}
+```

--- a/logger/README_zh.md
+++ b/logger/README_zh.md
@@ -1,0 +1,116 @@
+## 日志使用
+
+ 该 samples 演示了如何使用 lumberjack 配置 dubbo-go logger
+
+### 配置
+
+输出文件设置
+
+```yaml
+lumberjackConfig:
+  # 写日志的文件名称
+  filename: "logs.log"
+  # 每个日志文件长度的最大大小，默认100M
+  maxSize: 1
+  # 日志保留的最大天数(只保留最近多少天的日志)
+  maxAge: 3
+  # 只保留最近多少个日志文件，用于控制程序总日志的大小
+  maxBackups: 5
+  # 是否使用本地时间，默认使用UTC时间
+  localTime: true
+  # 是否压缩日志文件，压缩方法gzip
+  compress: false
+```
+
+zap 日志格式和级别设置
+
+```yaml
+zapConfig:
+  level: "debug"
+  development: false
+  disableCaller: false
+  disableStacktrace: false
+  sampling:
+  encoding: "console"
+
+  # encoder
+  encoderConfig:
+    messageKey: "message"
+    levelKey: "level"
+    timeKey: "time"
+    nameKey: "logger"
+    callerKey: "caller"
+    stacktraceKey: "stacktrace"
+    lineEnding: ""
+    levelEncoder: "capitalColor"
+    timeEncoder: "iso8601"
+    durationEncoder: "seconds"
+    callerEncoder: "short"
+    nameEncoder: ""
+
+  outputPaths:
+    - "stderr"
+  errorOutputPaths:
+    - "stderr"
+  initialFields:
+```
+
+如果不希望输出到文件中，可以按照如下规则，仅设置 zap
+
+```yaml
+  level: "debug"
+  development: false
+  disableCaller: false
+  disableStacktrace: false
+  sampling:
+  encoding: "console"
+
+  # encoder
+  encoderConfig:
+    messageKey: "message"
+    levelKey: "level"
+    timeKey: "time"
+    nameKey: "logger"
+    callerKey: "caller"
+    stacktraceKey: "stacktrace"
+    lineEnding: ""
+    levelEncoder: "capitalColor"
+    timeEncoder: "iso8601"
+    durationEncoder: "seconds"
+    callerEncoder: "short"
+    nameEncoder: ""
+
+  outputPaths:
+    - "stderr"
+  errorOutputPaths:
+    - "stderr"
+  initialFields:
+```
+
+### 运行
+
+在 go-client 端设置了一个 1000000 次的循环，会一直调用 server 来方便查看日志的输出情况
+
+```go
+func main() {
+	config.Load()
+	time.Sleep(3 * time.Second)
+
+	for i := 0;i < 1000000; i ++ {
+		test()
+	}
+
+}
+
+func test() {
+	logger.Info("\n\n\nstart to test dubbo")
+	user := &pkg.User{}
+	err := userProvider.GetUser(context.TODO(), []interface{}{"A001"}, user)
+	if err != nil {
+		logger.Infof("error: %v\n", err)
+		os.Exit(1)
+		return
+	}
+	logger.Infof("response result: %v\n", user)
+}
+```

--- a/logger/go-client/cmd/client.go
+++ b/logger/go-client/cmd/client.go
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"os"
+	"time"
+)
+
+import (
+	_ "dubbo.apache.org/dubbo-go/v3/cluster/cluster_impl"
+	_ "dubbo.apache.org/dubbo-go/v3/cluster/loadbalance"
+	_ "dubbo.apache.org/dubbo-go/v3/common/proxy/proxy_factory"
+	"dubbo.apache.org/dubbo-go/v3/config"
+	"dubbo.apache.org/dubbo-go/v3/common/logger"
+	_ "dubbo.apache.org/dubbo-go/v3/filter/filter_impl"
+	_ "dubbo.apache.org/dubbo-go/v3/protocol/dubbo"
+	_ "dubbo.apache.org/dubbo-go/v3/registry/protocol"
+	_ "dubbo.apache.org/dubbo-go/v3/registry/zookeeper"
+
+	hessian "github.com/apache/dubbo-go-hessian2"
+)
+
+import (
+	"github.com/apache/dubbo-go-samples/helloworld/go-client/pkg"
+)
+
+var userProvider = new(pkg.UserProvider)
+
+func init() {
+	config.SetConsumerService(userProvider)
+	hessian.RegisterPOJO(&pkg.User{})
+}
+
+// need to setup environment variable "CONF_CONSUMER_FILE_PATH" to "conf/client.yml" before run
+func main() {
+	config.Load()
+	time.Sleep(3 * time.Second)
+
+	for i := 0;i < 1000000; i ++ {
+		test()
+	}
+
+}
+
+func test() {
+	logger.Info("\n\n\nstart to test dubbo")
+	user := &pkg.User{}
+	err := userProvider.GetUser(context.TODO(), []interface{}{"A001"}, user)
+	if err != nil {
+		logger.Infof("error: %v\n", err)
+		os.Exit(1)
+		return
+	}
+	logger.Infof("response result: %v\n", user)
+}

--- a/logger/go-client/conf/client.yml
+++ b/logger/go-client/conf/client.yml
@@ -1,0 +1,59 @@
+# dubbo client yaml configure file
+
+check: true
+# client
+request_timeout: "3s"
+# connect timeout
+connect_timeout: "3s"
+
+# application config
+application:
+  organization: "dubbo.io"
+  name: "UserInfoClient"
+  module: "dubbo-go user-info client"
+  version: "0.0.1"
+  environment: "dev"
+
+# registry config
+registries:
+  "demoZk":
+    protocol: "zookeeper"
+    timeout: "3s"
+    address: "127.0.0.1:2181"
+    username: ""
+    password: ""
+
+# reference config
+references:
+  "UserProvider":
+    registry: "demoZk"
+    protocol: "dubbo"
+    interface: "org.apache.dubbo.UserProvider"
+    cluster: "failover"
+    methods:
+      - name: "GetUser"
+        retries: 3
+
+# protocol config
+protocol_conf:
+  dubbo:
+    reconnect_interval: 0
+    connection_number: 1
+    heartbeat_period: "5s"
+    session_timeout: "180s"
+    pool_size: 64
+    pool_ttl: 600
+    getty_session_param:
+      compress_encoding: false
+      tcp_no_delay: true
+      tcp_keep_alive: true
+      keep_alive_period: "120s"
+      tcp_r_buf_size: 262144
+      tcp_w_buf_size: 65536
+      pkg_rq_size: 1024
+      pkg_wq_size: 512
+      tcp_read_timeout: "1s"
+      tcp_write_timeout: "5s"
+      wait_timeout: "1s"
+      max_msg_len: 1024000
+      session_name: "client"

--- a/logger/go-client/conf/log.yml
+++ b/logger/go-client/conf/log.yml
@@ -1,0 +1,36 @@
+lumberjackConfig:
+  filename: "logs.log"
+  maxSize: 1
+  maxAge: 3
+  maxBackups: 5
+  localTime: true
+  compress: false
+
+zapConfig:
+  level: "debug"
+  development: false
+  disableCaller: false
+  disableStacktrace: false
+  sampling:
+  encoding: "console"
+
+  # encoder
+  encoderConfig:
+    messageKey: "message"
+    levelKey: "level"
+    timeKey: "time"
+    nameKey: "logger"
+    callerKey: "caller"
+    stacktraceKey: "stacktrace"
+    lineEnding: ""
+    levelEncoder: "capitalColor"
+    timeEncoder: "iso8601"
+    durationEncoder: "seconds"
+    callerEncoder: "short"
+    nameEncoder: ""
+
+  outputPaths:
+    - "stderr"
+  errorOutputPaths:
+    - "stderr"
+  initialFields:

--- a/logger/go-client/pkg/user.go
+++ b/logger/go-client/pkg/user.go
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pkg
+
+import (
+	"context"
+	"time"
+)
+
+type User struct {
+	ID   string
+	Name string
+	Age  int32
+	Time time.Time
+}
+
+type UserProvider struct {
+	GetUser func(ctx context.Context, req []interface{}, rsp *User) error
+}
+
+func (u *UserProvider) Reference() string {
+	return "UserProvider"
+}
+
+func (User) JavaClassName() string {
+	return "org.apache.dubbo.User"
+}

--- a/logger/go-server/cmd/server.go
+++ b/logger/go-server/cmd/server.go
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+import (
+	_ "dubbo.apache.org/dubbo-go/v3/cluster/cluster_impl"
+	_ "dubbo.apache.org/dubbo-go/v3/cluster/loadbalance"
+	"dubbo.apache.org/dubbo-go/v3/common/logger"
+	_ "dubbo.apache.org/dubbo-go/v3/common/proxy/proxy_factory"
+	"dubbo.apache.org/dubbo-go/v3/config"
+	_ "dubbo.apache.org/dubbo-go/v3/filter/filter_impl"
+	_ "dubbo.apache.org/dubbo-go/v3/protocol/dubbo"
+	_ "dubbo.apache.org/dubbo-go/v3/registry/protocol"
+	_ "dubbo.apache.org/dubbo-go/v3/registry/zookeeper"
+
+	hessian "github.com/apache/dubbo-go-hessian2"
+)
+
+import (
+	"github.com/apache/dubbo-go-samples/helloworld/go-server/pkg"
+)
+
+var (
+	survivalTimeout = int(3e9)
+)
+
+// need to setup environment variable "CONF_PROVIDER_FILE_PATH" to "conf/server.yml" before run
+func main() {
+	hessian.RegisterPOJO(&pkg.User{})
+	config.SetProviderService(new(pkg.UserProvider))
+	config.Load()
+
+	initSignal()
+}
+
+func initSignal() {
+	signals := make(chan os.Signal, 1)
+	// It is not possible to block SIGKILL or syscall.SIGSTOP
+	signal.Notify(signals, os.Interrupt, os.Kill, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	for {
+		sig := <-signals
+		logger.Infof("get signal %s", sig.String())
+		switch sig {
+		case syscall.SIGHUP:
+			// reload()
+		default:
+			time.AfterFunc(time.Duration(survivalTimeout), func() {
+				logger.Warnf("app exit now by force...")
+				os.Exit(1)
+			})
+
+			// The program exits normally or timeout forcibly exits.
+			fmt.Println("provider app exit now...")
+			return
+		}
+	}
+}

--- a/logger/go-server/conf/client.yml
+++ b/logger/go-server/conf/client.yml
@@ -1,0 +1,59 @@
+# dubbo client yaml configure file
+
+check: true
+# client
+request_timeout: "3s"
+# connect timeout
+connect_timeout: "3s"
+
+# application config
+application:
+  organization: "dubbo.io"
+  name: "UserInfoTest"
+  module: "dubbo-go user-info client"
+  version: "0.0.1"
+  environment: "dev"
+
+# registry config
+registries:
+  "demoZk":
+    protocol: "zookeeper"
+    timeout: "3s"
+    address: "127.0.0.1:2181"
+    username: ""
+    password: ""
+
+# reference config
+references:
+  "UserProvider":
+    registry: "demoZk"
+    protocol: "dubbo"
+    interface: "org.apache.dubbo.UserProvider"
+    cluster: "failover"
+    methods:
+      - name: "GetUser"
+        retries: 3
+
+# protocol config
+protocol_conf:
+  dubbo:
+    reconnect_interval: 0
+    connection_number: 1
+    heartbeat_period: "5s"
+    session_timeout: "180s"
+    pool_size: 64
+    pool_ttl: 600
+    getty_session_param:
+      compress_encoding: false
+      tcp_no_delay: true
+      tcp_keep_alive: true
+      keep_alive_period: "120s"
+      tcp_r_buf_size: 262144
+      tcp_w_buf_size: 65536
+      pkg_rq_size: 1024
+      pkg_wq_size: 512
+      tcp_read_timeout: "1s"
+      tcp_write_timeout: "5s"
+      wait_timeout: "1s"
+      max_msg_len: 1024000
+      session_name: "client"

--- a/logger/go-server/conf/log.yml
+++ b/logger/go-server/conf/log.yml
@@ -1,0 +1,36 @@
+lumberjackConfig:
+  filename: "logs.log"
+  maxSize: 4
+  maxAge: 3
+  maxBackups: 5
+  localTime: true
+  compress: false
+
+zapConfig:
+  level: "debug"
+  development: false
+  disableCaller: false
+  disableStacktrace: false
+  sampling:
+  encoding: "console"
+
+  # encoder
+  encoderConfig:
+    messageKey: "message"
+    levelKey: "level"
+    timeKey: "time"
+    nameKey: "logger"
+    callerKey: "caller"
+    stacktraceKey: "stacktrace"
+    lineEnding: ""
+    levelEncoder: "capitalColor"
+    timeEncoder: "iso8601"
+    durationEncoder: "seconds"
+    callerEncoder: "short"
+    nameEncoder: ""
+
+  outputPaths:
+    - "stderr"
+  errorOutputPaths:
+    - "stderr"
+  initialFields:

--- a/logger/go-server/conf/server.yml
+++ b/logger/go-server/conf/server.yml
@@ -1,0 +1,55 @@
+# dubbo server yaml configure file
+
+# application config
+application:
+  organization: "dubbo.io"
+  name: "UserInfoServer"
+  module: "dubbo-go user-info server"
+  version: "0.0.1"
+  environment: "dev"
+
+# registry config
+registries:
+  "demoZk":
+    protocol: "zookeeper"
+    timeout: "3s"
+    address: "127.0.0.1:2181"
+
+# service config
+services:
+  "UserProvider":
+    registry: "demoZk"
+    protocol: "dubbo"
+    interface: "org.apache.dubbo.UserProvider"
+    loadbalance: "random"
+    warmup: "100"
+    cluster: "failover"
+    methods:
+      - name: "GetUser"
+        retries: 1
+        loadbalance: "random"
+
+# protocol config
+protocols:
+  "dubbo":
+    name: "dubbo"
+    port: 20000
+
+protocol_conf:
+  dubbo:
+    session_number: 700
+    session_timeout: "180s"
+    getty_session_param:
+      compress_encoding: false
+      tcp_no_delay: true
+      tcp_keep_alive: true
+      keep_alive_period: "120s"
+      tcp_r_buf_size: 262144
+      tcp_w_buf_size: 65536
+      pkg_rq_size: 1024
+      pkg_wq_size: 512
+      tcp_read_timeout: "1s"
+      tcp_write_timeout: "5s"
+      wait_timeout: "1s"
+      max_msg_len: 1024000
+      session_name: "server"

--- a/logger/go-server/docker/docker-compose.yml
+++ b/logger/go-server/docker/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  zookeeper:
+    image: zookeeper
+    ports:
+      - 2181:2181
+    restart: on-failure
+

--- a/logger/go-server/docker/docker-health-check.sh
+++ b/logger/go-server/docker/docker-health-check.sh
@@ -1,0 +1,10 @@
+curl 127.0.0.1:2181
+res=$?
+passCode=52
+while [ "$res" != "$passCode" ];do
+  sleep 5
+  curl 127.0.0.1:2181
+  res=$?
+done
+
+sleep 5

--- a/logger/go-server/pkg/user.go
+++ b/logger/go-server/pkg/user.go
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pkg
+
+import (
+	"context"
+	"time"
+)
+
+import (
+	"github.com/dubbogo/gost/log"
+)
+
+type User struct {
+	ID   string
+	Name string
+	Age  int32
+	Time time.Time
+}
+
+type UserProvider struct {
+}
+
+func (u *UserProvider) GetUser(ctx context.Context, req []interface{}) (*User, error) {
+	gxlog.CInfo("req:%#v", req)
+	rsp := User{"A001", "Alex Stocks", 18, time.Now()}
+	gxlog.CInfo("rsp:%#v", rsp)
+	return &rsp, nil
+}
+
+func (u *UserProvider) Reference() string {
+	return "UserProvider"
+}
+
+func (u User) JavaClassName() string {
+	return "org.apache.dubbo.User"
+}

--- a/logger/go-server/tests/integration/main_test.go
+++ b/logger/go-server/tests/integration/main_test.go
@@ -1,0 +1,71 @@
+// +build integration
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+import (
+	_ "dubbo.apache.org/dubbo-go/v3/cluster/cluster_impl"
+	_ "dubbo.apache.org/dubbo-go/v3/cluster/loadbalance"
+	_ "dubbo.apache.org/dubbo-go/v3/common/proxy/proxy_factory"
+	"dubbo.apache.org/dubbo-go/v3/config"
+	_ "dubbo.apache.org/dubbo-go/v3/filter/filter_impl"
+	_ "dubbo.apache.org/dubbo-go/v3/metadata/service/local"
+	_ "dubbo.apache.org/dubbo-go/v3/protocol/dubbo"
+	_ "dubbo.apache.org/dubbo-go/v3/registry/protocol"
+	_ "dubbo.apache.org/dubbo-go/v3/registry/zookeeper"
+
+	hessian "github.com/apache/dubbo-go-hessian2"
+)
+
+var userProvider = new(UserProvider)
+
+func TestMain(m *testing.M) {
+	config.SetConsumerService(userProvider)
+	hessian.RegisterPOJO(&User{})
+	config.Load()
+	time.Sleep(3 * time.Second)
+
+	os.Exit(m.Run())
+}
+
+type User struct {
+	ID   string
+	Name string
+	Age  int32
+	Time time.Time
+}
+
+type UserProvider struct {
+	GetUser func(ctx context.Context, req []interface{}, rsp *User) error
+}
+
+func (u *UserProvider) Reference() string {
+	return "UserProvider"
+}
+
+func (User) JavaClassName() string {
+	return "org.apache.dubbo.User"
+}

--- a/logger/go-server/tests/integration/userprovider_test.go
+++ b/logger/go-server/tests/integration/userprovider_test.go
@@ -1,0 +1,39 @@
+// +build integration
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"context"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetUser(t *testing.T) {
+	user := &User{}
+	err := userProvider.GetUser(context.TODO(), []interface{}{"A001"}, user)
+	assert.Nil(t, err)
+	assert.Equal(t, "A001", user.ID)
+	assert.Equal(t, "Alex Stocks", user.Name)
+	assert.Equal(t, int32(18), user.Age)
+	assert.NotNil(t, user.Time)
+}


### PR DESCRIPTION
对应 dubbo-go 中的 pr 为 https://github.com/apache/dubbo-go/pull/1335
* 添加日志切分的样例
* 为日志切分样例添加 .run.xml 文件，可以在 goland 中快速启动
* 修复 .run 目录中的 tracting 的 .run.xml 文件 env 的错误路径
* 功能详细介绍在 README 中