### PR TITLE
Change generic invocation sample to fit the change in dubbo-go

### DIFF
--- a/generic/go-client/cmd/client.go
+++ b/generic/go-client/cmd/client.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/apache/dubbo-go/registry/protocol"
 	_ "github.com/apache/dubbo-go/registry/zookeeper"
 
+	hessian "github.com/apache/dubbo-go-hessian2"
 	"github.com/dubbogo/gost/log"
 )
 
@@ -66,6 +67,8 @@ func main() {
 	callGetUser()
 	gxlog.CInfo("\n\ncall queryUser")
 	callQueryUser()
+	gxlog.CInfo("\n\ncall getAllUsers")
+	callGetAllUsers()
 	initSignal()
 }
 
@@ -100,7 +103,7 @@ func callGetUser() {
 		[]interface{}{
 			"GetUser",
 			[]string{"java.lang.String"},
-			[]interface{}{"A003"},
+			[]hessian.Object{"A003"},
 		},
 	)
 	if err != nil {
@@ -110,6 +113,7 @@ func callGetUser() {
 	gxlog.CInfo("success!")
 
 }
+
 func callQueryUser() {
 	gxlog.CInfo("\n\n\nstart to generic invoke")
 	user := pkg.User{
@@ -123,7 +127,25 @@ func callQueryUser() {
 		[]interface{}{
 			"queryUser",
 			[]string{"org.apache.dubbo.User"},
-			[]interface{}{user},
+			[]hessian.Object{user},
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+	gxlog.CInfo("res: %+v\n", resp)
+	gxlog.CInfo("success!")
+
+}
+
+func callGetAllUsers() {
+	gxlog.CInfo("\n\n\nstart to generic invoke")
+	resp, err := referenceConfig.GetRPCService().(*config.GenericService).Invoke(
+		context.TODO(),
+		[]interface{}{
+			"GetAllUsers",
+			[]hessian.Object{},
+			[]hessian.Object{},
 		},
 	)
 	if err != nil {

--- a/generic/go-server/pkg/user.go
+++ b/generic/go-server/pkg/user.go
@@ -59,6 +59,15 @@ func (u *UserProvider) QueryUser(ctx context.Context, user *User) (*User, error)
 	return &rsp, nil
 }
 
+func (u *UserProvider) GetAllUsers(ctx context.Context) ([]*User, error) {
+	rsp := []*User{
+		{"A001", "Alex Stocks", 18, time.Now()},
+		{"A002", "Alchemy Lee", 12, time.Now()},
+	}
+	gxlog.CInfo("rsp:%#v", rsp)
+	return rsp, nil
+}
+
 func (u *UserProvider) MethodMapper() map[string]string {
 	return map[string]string{
 		"QueryUser": "queryUser",


### PR DESCRIPTION
This PR changes the generic invocation sample to fit the change in dubbo-go. In detail, it changes the slice type in `GenericService` from `[]interface{}` to `[]hessian.Object`. In addition, it adds a non-parameter generic invocation in the sample.