### PR TITLE
feat(geninv): add samples for generic invocation using hessian and Triple

### DIFF
--- a/api/samples_api.pb.go
+++ b/api/samples_api.pb.go
@@ -23,8 +23,6 @@ package api
 import (
 	context "context"
 	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
-	grpc "google.golang.org/grpc"
 	math "math"
 )
 
@@ -32,9 +30,14 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 	dgrpc "dubbo.apache.org/dubbo-go/v3/protocol/dubbo3"
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
+
 	"github.com/dubbogo/triple/pkg/common"
 	tripleConstant "github.com/dubbogo/triple/pkg/common/constant"
 	dubbo3 "github.com/dubbogo/triple/pkg/triple"
+
+	proto "github.com/golang/protobuf/proto"
+
+	grpc "google.golang.org/grpc"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/generic/default/go-client/cmd/client.go
+++ b/generic/default/go-client/cmd/client.go
@@ -20,10 +20,6 @@ package main
 import (
 	"context"
 	"dubbo.apache.org/dubbo-go/v3/protocol/dubbo"
-	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
 	"time"
 )
 
@@ -69,7 +65,6 @@ func main() {
 	callQueryUsers(tripleRefConf)
 	//callQueryAll(tripleRefConf)
 
-	initSignal()
 }
 
 func callGetUser(refConf config.ReferenceConfig) {
@@ -258,28 +253,4 @@ func newRefConf(iface, protocol string) config.ReferenceConfig {
 	refConf.GenericLoad(appName)
 
 	return refConf
-}
-
-func initSignal() {
-	signals := make(chan os.Signal, 1)
-	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, os.Kill, syscall.SIGHUP,
-		syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
-	for {
-		sig := <-signals
-		logger.Infof("get signal %s", sig.String())
-		switch sig {
-		case syscall.SIGHUP:
-			// reload()
-		default:
-			time.AfterFunc(10*time.Second, func() {
-				logger.Warnf("app exit now by force...")
-				os.Exit(1)
-			})
-
-			// The program exits normally or timeout forcibly exits.
-			fmt.Println("app exit now...")
-			return
-		}
-	}
 }

--- a/generic/default/go-client/cmd/client.go
+++ b/generic/default/go-client/cmd/client.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"context"
-	"dubbo.apache.org/dubbo-go/v3/protocol/dubbo"
 	"time"
 )
 
@@ -28,9 +27,11 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/config/generic"
 	_ "dubbo.apache.org/dubbo-go/v3/imports"
-	tpconst "github.com/dubbogo/triple/pkg/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/protocol/dubbo"
 
 	hessian "github.com/apache/dubbo-go-hessian2"
+
+	tpconst "github.com/dubbogo/triple/pkg/common/constant"
 )
 
 import (

--- a/generic/default/go-client/cmd/client.go
+++ b/generic/default/go-client/cmd/client.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"context"
+	"dubbo.apache.org/dubbo-go/v3/protocol/dubbo"
 	"fmt"
 	"os"
 	"os/signal"
@@ -27,16 +28,11 @@ import (
 )
 
 import (
-	_ "dubbo.apache.org/dubbo-go/v3/cluster/cluster_impl"
-	_ "dubbo.apache.org/dubbo-go/v3/cluster/loadbalance"
 	"dubbo.apache.org/dubbo-go/v3/common/logger"
-	_ "dubbo.apache.org/dubbo-go/v3/common/proxy/proxy_factory"
 	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/config/generic"
-	_ "dubbo.apache.org/dubbo-go/v3/filter/filter_impl"
-	"dubbo.apache.org/dubbo-go/v3/protocol/dubbo"
-	_ "dubbo.apache.org/dubbo-go/v3/registry/protocol"
-	_ "dubbo.apache.org/dubbo-go/v3/registry/zookeeper"
+	_ "dubbo.apache.org/dubbo-go/v3/imports"
+	tpconst "github.com/dubbogo/triple/pkg/common/constant"
 
 	hessian "github.com/apache/dubbo-go-hessian2"
 )
@@ -45,9 +41,7 @@ import (
 	"github.com/apache/dubbo-go-samples/generic/default/go-client/pkg"
 )
 
-var (
-	appName = "dubbo.io"
-)
+const appName = "dubbo.io"
 
 // export DUBBO_GO_CONFIG_PATH= PATH_TO_SAMPLES/generic/default/go-client/conf/dubbogo.yml
 func main() {
@@ -66,7 +60,14 @@ func main() {
 	//callQueryAll(dubboRefConf)
 
 	// generic invocation samples using hessian serialization on Triple protocol
-	//tripleRefConf := newRefConf("org.apache.dubbo.samples.UserProviderTriple", tpconst.TRIPLE)
+	tripleRefConf := newRefConf("org.apache.dubbo.samples.UserProviderTriple", tpconst.TRIPLE)
+	callGetUser(tripleRefConf)
+	//callGetOneUser(tripleRefConf)
+	callGetUsers(tripleRefConf)
+	callGetUsersMap(tripleRefConf)
+	callQueryUser(tripleRefConf)
+	callQueryUsers(tripleRefConf)
+	//callQueryAll(tripleRefConf)
 
 	initSignal()
 }

--- a/generic/default/go-server/cmd/server.go
+++ b/generic/default/go-server/cmd/server.go
@@ -34,7 +34,7 @@ import (
 )
 
 import (
-	pkg "github.com/apache/dubbo-go-samples/generic/default/go-server/pkg"
+	"github.com/apache/dubbo-go-samples/generic/default/go-server/pkg"
 )
 
 // export DUBBO_GO_CONFIG_PATH= PATH_TO_SAMPLES/generic/default/go-server/conf/dubbogo.yml

--- a/integrate_test/generic/default/tests/integration/main_test.go
+++ b/integrate_test/generic/default/tests/integration/main_test.go
@@ -18,38 +18,35 @@
 package integration
 
 import (
+	tpconst "github.com/dubbogo/triple/pkg/common/constant"
 	"os"
 	"testing"
 )
 
 import (
-	_ "dubbo.apache.org/dubbo-go/v3/cluster/cluster_impl"
-	_ "dubbo.apache.org/dubbo-go/v3/cluster/loadbalance"
-	_ "dubbo.apache.org/dubbo-go/v3/common/proxy/proxy_factory"
 	"dubbo.apache.org/dubbo-go/v3/config"
-	_ "dubbo.apache.org/dubbo-go/v3/filter/filter_impl"
+	_ "dubbo.apache.org/dubbo-go/v3/imports"
 	"dubbo.apache.org/dubbo-go/v3/protocol/dubbo"
-	_ "dubbo.apache.org/dubbo-go/v3/protocol/dubbo"
-	_ "dubbo.apache.org/dubbo-go/v3/registry/protocol"
-	_ "dubbo.apache.org/dubbo-go/v3/registry/zookeeper"
 
 	hessian "github.com/apache/dubbo-go-hessian2"
 )
 
 import (
-	pkg "github.com/apache/dubbo-go-samples/generic/default/go-server/pkg"
+	"github.com/apache/dubbo-go-samples/generic/default/go-server/pkg"
 )
 
+const appName = "dubbo.io"
+
 var (
-	appName      = "dubbo.io"
 	dubboRefConf config.ReferenceConfig
-	//tripleRefConf config.ReferenceConfig
+	tripleRefConf config.ReferenceConfig
 )
 
 func TestMain(m *testing.M) {
 	hessian.RegisterPOJO(&pkg.User{})
 
 	dubboRefConf = newRefConf("org.apache.dubbo.samples.UserProvider", dubbo.DUBBO)
+	tripleRefConf = newRefConf("org.apache.dubbo.samples.UserProviderTriple", tpconst.TRIPLE)
 
 	os.Exit(m.Run())
 }

--- a/integrate_test/generic/default/tests/integration/main_test.go
+++ b/integrate_test/generic/default/tests/integration/main_test.go
@@ -38,7 +38,7 @@ import (
 const appName = "dubbo.io"
 
 var (
-	dubboRefConf config.ReferenceConfig
+	dubboRefConf  config.ReferenceConfig
 	tripleRefConf config.ReferenceConfig
 )
 

--- a/integrate_test/generic/default/tests/integration/main_test.go
+++ b/integrate_test/generic/default/tests/integration/main_test.go
@@ -18,7 +18,6 @@
 package integration
 
 import (
-	tpconst "github.com/dubbogo/triple/pkg/common/constant"
 	"os"
 	"testing"
 )
@@ -29,6 +28,8 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/protocol/dubbo"
 
 	hessian "github.com/apache/dubbo-go-hessian2"
+
+	tpconst "github.com/dubbogo/triple/pkg/common/constant"
 )
 
 import (

--- a/integrate_test/generic/default/tests/integration/userprovider_test.go
+++ b/integrate_test/generic/default/tests/integration/userprovider_test.go
@@ -31,6 +31,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+import (
+	"github.com/apache/dubbo-go-samples/generic/default/go-client/pkg"
+)
+
 func TestGetUser1(t *testing.T) {
 	o, err := dubboRefConf.GetRPCService().(*generic.GenericService).Invoke(
 		context.TODO(),
@@ -41,6 +45,19 @@ func TestGetUser1(t *testing.T) {
 	assert.Nil(t, err)
 	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
 	resp := o.(map[interface{}]interface{})
+	assert.Equal(t, "Joe", resp["name"])
+	assert.Equal(t, int32(48), resp["age"])
+	assert.Equal(t, "A003", resp["iD"])
+
+	o, err = tripleRefConf.GetRPCService().(*generic.GenericService).Invoke(
+		context.TODO(),
+		"GetUser1",
+		[]string{"java.lang.String"},
+		[]hessian.Object{"A003"},
+	)
+	assert.Nil(t, err)
+	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
+	resp = o.(map[interface{}]interface{})
 	assert.Equal(t, "Joe", resp["name"])
 	assert.Equal(t, int32(48), resp["age"])
 	assert.Equal(t, "A003", resp["iD"])
@@ -59,6 +76,19 @@ func TestGetUser2(t *testing.T) {
 	assert.Equal(t, "lily", resp["name"])
 	assert.Equal(t, int32(48), resp["age"])
 	assert.Equal(t, "A003", resp["iD"])
+
+	o, err = tripleRefConf.GetRPCService().(*generic.GenericService).Invoke(
+		context.TODO(),
+		"GetUser2",
+		[]string{"java.lang.String", "java.lang.String"},
+		[]hessian.Object{"A003", "lily"},
+	)
+	assert.Nil(t, err)
+	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
+	resp = o.(map[interface{}]interface{})
+	assert.Equal(t, "lily", resp["name"])
+	assert.Equal(t, int32(48), resp["age"])
+	assert.Equal(t, "A003", resp["iD"])
 }
 
 func TestGetUser3(t *testing.T) {
@@ -74,6 +104,19 @@ func TestGetUser3(t *testing.T) {
 	assert.Equal(t, "Alex Stocks", resp["name"])
 	assert.Equal(t, int32(18), resp["age"])
 	assert.Equal(t, "1", resp["iD"])
+
+	o, err = tripleRefConf.GetRPCService().(*generic.GenericService).Invoke(
+		context.TODO(),
+		"GetUser3",
+		[]string{"int"},
+		[]hessian.Object{1},
+	)
+	assert.Nil(t, err)
+	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
+	resp = o.(map[interface{}]interface{})
+	assert.Equal(t, "Alex Stocks", resp["name"])
+	assert.Equal(t, int32(18), resp["age"])
+	assert.Equal(t, "1", resp["iD"])
 }
 
 func TestGetUser4(t *testing.T) {
@@ -86,6 +129,19 @@ func TestGetUser4(t *testing.T) {
 	assert.Nil(t, err)
 	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
 	resp := o.(map[interface{}]interface{})
+	assert.Equal(t, "zhangsan", resp["name"])
+	assert.Equal(t, int32(18), resp["age"])
+	assert.Equal(t, "1", resp["iD"])
+
+	o, err = tripleRefConf.GetRPCService().(*generic.GenericService).Invoke(
+		context.TODO(),
+		"GetUser4",
+		[]string{"int", "java.lang.String"},
+		[]hessian.Object{1, "zhangsan"},
+	)
+	assert.Nil(t, err)
+	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
+	resp = o.(map[interface{}]interface{})
 	assert.Equal(t, "zhangsan", resp["name"])
 	assert.Equal(t, int32(18), resp["age"])
 	assert.Equal(t, "1", resp["iD"])
@@ -105,6 +161,8 @@ func TestGetUser4(t *testing.T) {
 //	assert.Equal(t, "xavierniu", resp["name"])
 //	assert.Equal(t, int32(24), resp["age"])
 //	assert.Equal(t, "1000", resp["iD"])
+//
+// TODO: Triple protocol test is required.
 //}
 
 func TestGetUsers(t *testing.T) {
@@ -120,11 +178,29 @@ func TestGetUsers(t *testing.T) {
 	)
 	assert.Nil(t, err)
 	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
-	//resp := o.(map[interface{}]interface{})
-	//assert.Equal(t, "other-zhangsan", resp[0].(*pkg.User).Name)
-	//assert.Equal(t, "other-lisi", resp[1].(*pkg.User).Name)
-	//assert.Equal(t, "other-lily", resp[2].(*pkg.User).Name)
-	//assert.Equal(t, "other-lisa", resp[3].(*pkg.User).Name)
+	resp := o.(map[interface{}]interface{})
+	assert.Equal(t, "other-zhangsan", resp[0].(*pkg.User).Name)
+	assert.Equal(t, "other-lisi", resp[1].(*pkg.User).Name)
+	assert.Equal(t, "other-lily", resp[2].(*pkg.User).Name)
+	assert.Equal(t, "other-lisa", resp[3].(*pkg.User).Name)
+
+	o, err = tripleRefConf.GetRPCService().(*generic.GenericService).Invoke(
+		context.TODO(),
+		"GetUsers",
+		[]string{"java.util.List"},
+		[]hessian.Object{
+			[]hessian.Object{
+				"001", "002", "003", "004",
+			},
+		},
+	)
+	assert.Nil(t, err)
+	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
+	resp = o.(map[interface{}]interface{})
+	assert.Equal(t, "other-zhangsan", resp[0].(*pkg.User).Name)
+	assert.Equal(t, "other-lisi", resp[1].(*pkg.User).Name)
+	assert.Equal(t, "other-lily", resp[2].(*pkg.User).Name)
+	assert.Equal(t, "other-lisa", resp[3].(*pkg.User).Name)
 }
 
 func TestQueryUser(t *testing.T) {
@@ -146,49 +222,92 @@ func TestQueryUser(t *testing.T) {
 	assert.Equal(t, "panty", resp["name"])
 	assert.Equal(t, int32(25), resp["age"])
 	assert.Equal(t, "3213", resp["iD"])
+
+	o, err = tripleRefConf.GetRPCService().(*generic.GenericService).Invoke(
+		context.TODO(),
+		"queryUser",
+		[]string{"org.apache.dubbo.User"},
+		[]hessian.Object{map[string]hessian.Object{
+			"iD":   "3213",
+			"name": "panty",
+			"age":  25,
+			"time": time.Now(),
+		}},
+	)
+
+	assert.Nil(t, err)
+	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
+	resp = o.(map[interface{}]interface{})
+	assert.Equal(t, "panty", resp["name"])
+	assert.Equal(t, int32(25), resp["age"])
+	assert.Equal(t, "3213", resp["iD"])
 }
 
-//
-//func TestQueryUsers(t *testing.T) {
-//	o, err := referenceConfig.GetRPCService().(*generic.GenericService).Invoke(
-//		context.TODO(),
-//		[]interface{}{
-//			"queryUsers",
-//			[]string{"org.apache.dubbo.User"},
-//			[]hessian.Object{
-//				map[string]hessian.Object{
-//					"id":    "3212",
-//					"name":  "XavierNiu",
-//					"age":   24,
-//					"time":  time.Now().Add(4),
-//					"class": "org.apache.dubbo.User",
-//				},
-//				map[string]hessian.Object{
-//					"iD":    "3213",
-//					"name":  "zhangsan",
-//					"age":   21,
-//					"time":  time.Now().Add(4),
-//					"class": "org.apache.dubbo.User",
-//				},
-//			},
-//		},
-//	)
-//
-//	assert.Nil(t, err)
-//	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
-//	resp := o.(map[interface{}]interface{})
-//	assert.Equal(t, "XavierNiu", resp[0].(*pkg.User).Name)
-//	assert.Equal(t, "zhangsan", resp[1].(*pkg.User).Name)
-//}
-//
+func TestQueryUsers(t *testing.T) {
+	o, err := dubboRefConf.GetRPCService().(*generic.GenericService).Invoke(
+		context.TODO(),
+		"queryUsers",
+		[]string{"org.apache.dubbo.User"},
+		[]hessian.Object{
+			map[string]hessian.Object{
+				"id":    "3212",
+				"name":  "XavierNiu",
+				"age":   24,
+				"time":  time.Now().Add(4),
+				"class": "org.apache.dubbo.User",
+			},
+			map[string]hessian.Object{
+				"iD":    "3213",
+				"name":  "zhangsan",
+				"age":   21,
+				"time":  time.Now().Add(4),
+				"class": "org.apache.dubbo.User",
+			},
+		},
+	)
+
+	assert.Nil(t, err)
+	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
+	resp := o.(map[interface{}]interface{})
+	assert.Equal(t, "XavierNiu", resp[0].(*pkg.User).Name)
+	assert.Equal(t, "zhangsan", resp[1].(*pkg.User).Name)
+
+	o, err = tripleRefConf.GetRPCService().(*generic.GenericService).Invoke(
+		context.TODO(),
+		"queryUsers",
+		[]string{"org.apache.dubbo.User"},
+		[]hessian.Object{
+			map[string]hessian.Object{
+				"id":    "3212",
+				"name":  "XavierNiu",
+				"age":   24,
+				"time":  time.Now().Add(4),
+				"class": "org.apache.dubbo.User",
+			},
+			map[string]hessian.Object{
+				"iD":    "3213",
+				"name":  "zhangsan",
+				"age":   21,
+				"time":  time.Now().Add(4),
+				"class": "org.apache.dubbo.User",
+			},
+		},
+	)
+
+	assert.Nil(t, err)
+	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
+	resp = o.(map[interface{}]interface{})
+	assert.Equal(t, "XavierNiu", resp[0].(*pkg.User).Name)
+	assert.Equal(t, "zhangsan", resp[1].(*pkg.User).Name)
+}
+
+// TODO: Waiting for hessian-go bugfix
 //func TestQueryAll(t *testing.T) {
-//	o, err := referenceConfig.GetRPCService().(*generic.GenericService).Invoke(
+//	o, err := dubboRefConf.GetRPCService().(*generic.GenericService).Invoke(
 //		context.TODO(),
-//		[]interface{}{
 //			"queryAll",
 //			[]hessian.Object{},
 //			[]hessian.Object{},
-//		},
 //	)
 //
 //	assert.Nil(t, err)

--- a/integrate_test/generic/default/tests/integration/userprovider_test.go
+++ b/integrate_test/generic/default/tests/integration/userprovider_test.go
@@ -31,10 +31,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-import (
-	"github.com/apache/dubbo-go-samples/generic/default/go-client/pkg"
-)
-
 func TestGetUser1(t *testing.T) {
 	o, err := dubboRefConf.GetRPCService().(*generic.GenericService).Invoke(
 		context.TODO(),
@@ -179,10 +175,10 @@ func TestGetUsers(t *testing.T) {
 	assert.Nil(t, err)
 	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
 	resp := o.(map[interface{}]interface{})
-	assert.Equal(t, "other-zhangsan", resp[0].(*pkg.User).Name)
-	assert.Equal(t, "other-lisi", resp[1].(*pkg.User).Name)
-	assert.Equal(t, "other-lily", resp[2].(*pkg.User).Name)
-	assert.Equal(t, "other-lisa", resp[3].(*pkg.User).Name)
+	assert.Equal(t, "other-zhangsan", resp["users"].([]interface{})[0].(map[interface{}]interface{})["name"])
+	assert.Equal(t, "other-lisi", resp["users"].([]interface{})[1].(map[interface{}]interface{})["name"])
+	assert.Equal(t, "other-lily", resp["users"].([]interface{})[2].(map[interface{}]interface{})["name"])
+	assert.Equal(t, "other-lisa", resp["users"].([]interface{})[3].(map[interface{}]interface{})["name"])
 
 	o, err = tripleRefConf.GetRPCService().(*generic.GenericService).Invoke(
 		context.TODO(),
@@ -197,10 +193,10 @@ func TestGetUsers(t *testing.T) {
 	assert.Nil(t, err)
 	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
 	resp = o.(map[interface{}]interface{})
-	assert.Equal(t, "other-zhangsan", resp[0].(*pkg.User).Name)
-	assert.Equal(t, "other-lisi", resp[1].(*pkg.User).Name)
-	assert.Equal(t, "other-lily", resp[2].(*pkg.User).Name)
-	assert.Equal(t, "other-lisa", resp[3].(*pkg.User).Name)
+	assert.Equal(t, "other-zhangsan", resp["users"].([]interface{})[0].(map[interface{}]interface{})["name"])
+	assert.Equal(t, "other-lisi", resp["users"].([]interface{})[1].(map[interface{}]interface{})["name"])
+	assert.Equal(t, "other-lily", resp["users"].([]interface{})[2].(map[interface{}]interface{})["name"])
+	assert.Equal(t, "other-lisa", resp["users"].([]interface{})[3].(map[interface{}]interface{})["name"])
 }
 
 func TestQueryUser(t *testing.T) {
@@ -247,58 +243,62 @@ func TestQueryUsers(t *testing.T) {
 	o, err := dubboRefConf.GetRPCService().(*generic.GenericService).Invoke(
 		context.TODO(),
 		"queryUsers",
-		[]string{"org.apache.dubbo.User"},
+		[]string{"java.util.List"},
 		[]hessian.Object{
-			map[string]hessian.Object{
-				"id":    "3212",
-				"name":  "XavierNiu",
-				"age":   24,
-				"time":  time.Now().Add(4),
-				"class": "org.apache.dubbo.User",
-			},
-			map[string]hessian.Object{
-				"iD":    "3213",
-				"name":  "zhangsan",
-				"age":   21,
-				"time":  time.Now().Add(4),
-				"class": "org.apache.dubbo.User",
+			[]hessian.Object{
+				map[string]hessian.Object{
+					"id":    "3212",
+					"name":  "XavierNiu",
+					"age":   24,
+					"time":  time.Now(),
+					"class": "org.apache.dubbo.User",
+				},
+				map[string]hessian.Object{
+					"iD":    "3213",
+					"name":  "zhangsan",
+					"age":   21,
+					"time":  time.Now(),
+					"class": "org.apache.dubbo.User",
+				},
 			},
 		},
 	)
 
 	assert.Nil(t, err)
-	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
-	resp := o.(map[interface{}]interface{})
-	assert.Equal(t, "XavierNiu", resp[0].(*pkg.User).Name)
-	assert.Equal(t, "zhangsan", resp[1].(*pkg.User).Name)
+	resp, ok := o.(map[interface{}]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "XavierNiu", resp["users"].([]interface{})[0].(map[interface{}]interface{})["name"])
+	assert.Equal(t, "zhangsan", resp["users"].([]interface{})[1].(map[interface{}]interface{})["name"])
 
 	o, err = tripleRefConf.GetRPCService().(*generic.GenericService).Invoke(
 		context.TODO(),
 		"queryUsers",
 		[]string{"org.apache.dubbo.User"},
 		[]hessian.Object{
-			map[string]hessian.Object{
-				"id":    "3212",
-				"name":  "XavierNiu",
-				"age":   24,
-				"time":  time.Now().Add(4),
-				"class": "org.apache.dubbo.User",
-			},
-			map[string]hessian.Object{
-				"iD":    "3213",
-				"name":  "zhangsan",
-				"age":   21,
-				"time":  time.Now().Add(4),
-				"class": "org.apache.dubbo.User",
+			[]hessian.Object{
+				map[string]hessian.Object{
+					"id":    "3212",
+					"name":  "XavierNiu",
+					"age":   24,
+					"time":  time.Now(),
+					"class": "org.apache.dubbo.User",
+				},
+				map[string]hessian.Object{
+					"iD":    "3213",
+					"name":  "zhangsan",
+					"age":   21,
+					"time":  time.Now(),
+					"class": "org.apache.dubbo.User",
+				},
 			},
 		},
 	)
 
 	assert.Nil(t, err)
-	assert.IsType(t, make(map[interface{}]interface{}, 0), o)
-	resp = o.(map[interface{}]interface{})
-	assert.Equal(t, "XavierNiu", resp[0].(*pkg.User).Name)
-	assert.Equal(t, "zhangsan", resp[1].(*pkg.User).Name)
+	resp, ok = o.(map[interface{}]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "XavierNiu", resp["users"].([]interface{})[0].(map[interface{}]interface{})["name"])
+	assert.Equal(t, "zhangsan", resp["users"].([]interface{})[1].(map[interface{}]interface{})["name"])
 }
 
 // TODO: Waiting for hessian-go bugfix


### PR DESCRIPTION
What's new:

- Add integrated tests of generic invocation that use Triple and hessian
- Fix some tests that couldn't work
- Format import blocks
- Remove `initSignal` from generic invocation client