### PR TITLE
fix: logger/custom/conf/dubbogo.yml syntax error

### DIFF
--- a/logger/custom/conf/dubbogo.yml
+++ b/logger/custom/conf/dubbogo.yml
@@ -9,7 +9,7 @@ dubbo:
       name: tri
       port: 20000
   provider:
-    registryIDs:
+    registry-ids:
       - demoZK
     services:
       greeterImpl:

--- a/logger/custom/conf/dubbogo.yml
+++ b/logger/custom/conf/dubbogo.yml
@@ -9,7 +9,7 @@ dubbo:
       name: tri
       port: 20000
   provider:
-    registryIDs
+    registryIDs:
       - demoZK
     services:
       greeterImpl:


### PR DESCRIPTION
logger/custom/confdubbogo.yml file line 12 has syntax error