### PR TITLE
fix: Fix log import issues

### DIFF
--- a/context/dubbo/go-client/cmd/client.go
+++ b/context/dubbo/go-client/cmd/client.go
@@ -29,7 +29,7 @@ import (
 
 	hessian "github.com/apache/dubbo-go-hessian2"
 
-	"github.com/dubbogo/gost/log"
+	gxlog "github.com/dubbogo/gost/log"
 )
 
 type UserProvider struct {

--- a/filter/tpslimit/go-server/pkg/limit_strategy.go
+++ b/filter/tpslimit/go-server/pkg/limit_strategy.go
@@ -25,7 +25,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/filter"
 
-	"github.com/dubbogo/gost/log"
+	gxlog "github.com/dubbogo/gost/log"
 )
 
 func init() {

--- a/registry/etcd/go-server/pkg/user.go
+++ b/registry/etcd/go-server/pkg/user.go
@@ -27,7 +27,7 @@ import (
 
 	hessian "github.com/apache/dubbo-go-hessian2"
 
-	"github.com/dubbogo/gost/log"
+	gxlog "github.com/dubbogo/gost/log"
 )
 
 func init() {


### PR DESCRIPTION
There are three files that not set log alias correctly, which lead to throw static typecheck errors from GitHub.