### PR TITLE
ci: Fix go build issues

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -43,13 +43,10 @@ export GONOPROXY ?= **.gitee.com**
 OS := $(shell uname)
 ifeq ($(OS), Linux)
 	export GOOS ?= linux
-	export DOCKER_HOST_IP = $(shell ifconfig enp3s0 | grep inet | grep -v inet6 | awk '{print $$2}')
 else ifeq ($(OS), Darwin)
 	export GOOS ?= darwin
-	export DOCKER_HOST_IP = $(shell ifconfig en0 | grep inet | grep -v inet6 | awk '{print $$2}')
 else
 	export GOOS ?= windows
-	export DOCKER_HOST_IP = $(shell ifconfig en0 | grep inet | grep -v inet6 | awk '{print $$2}')
 endif
 
 ifeq ($(GOOS), windows)
@@ -97,7 +94,7 @@ build: $(OUT_DIR)/$(PROJECT_NAME)$(EXT_NAME)
 .PHONY: $(OUT_DIR)/$(PROJECT_NAME)$(EXT_NAME)
 $(OUT_DIR)/$(PROJECT_NAME)$(EXT_NAME):
 	$(info   >  Buiding application binary: $(OUT_DIR)/$(PROJECT_NAME)$(EXT_NAME))
-	@CGO_ENABLED=$(CGO) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -i -o $(OUT_DIR)/$(PROJECT_NAME)$(EXT_NAME) $(SOURCES)
+	@CGO_ENABLED=$(CGO) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -o $(OUT_DIR)/$(PROJECT_NAME)$(EXT_NAME) $(SOURCES)
 
 ## docker-health-check: check services health on docker
 .PHONY: docker-health-check

--- a/rpc/jsonrpc/go-client/conf/dubbogo.yml
+++ b/rpc/jsonrpc/go-client/conf/dubbogo.yml
@@ -18,12 +18,12 @@ dubbo:
       UserProvider1:
         protocol: jsonrpc
         version: 2.0
-        interface: org.apache.dubbo.samples.UserProvider
+        interface: org.apache.dubbo.samples.UserProvider1
       UserProvider2:
         protocol: jsonrpc
         version: 2.0
         group: as
-        interface: org.apache.dubbo.samples.UserProvider
+        interface: org.apache.dubbo.samples.UserProvider2
   logger:
     zap-config:
       level: info

--- a/rpc/jsonrpc/go-server/conf/dubbogo.yml
+++ b/rpc/jsonrpc/go-server/conf/dubbogo.yml
@@ -19,10 +19,10 @@ dubbo:
       UserProvider:
         interface: org.apache.dubbo.samples.UserProvider
       UserProvider1:
-        interface: org.apache.dubbo.samples.UserProvider
+        interface: org.apache.dubbo.samples.UserProvider1
         version: 2.0
       UserProvider2:
-        interface: org.apache.dubbo.samples.UserProvider
+        interface: org.apache.dubbo.samples.UserProvider2
         version: 2.0
         group: as
   logger:


### PR DESCRIPTION
`-i` flag was removed from the Go 1.17, see
https://github.com/golang/go/issues/41696. Besides, this PR fixes a jsonrpc issue that has three same interface names.

`DOCKER_HOST_IP` is not used. Obtaining it depends on ifconfig, which is not built-in on Ubuntu. This could lead to the command not found issue.

Signed-off-by: Xuewei Niu <justxuewei@apache.org>