### PR TITLE
ci: Bump Go version of CI to 1.17

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,7 +15,7 @@ jobs:
       # If you want to matrix build , you can append the following list.
       matrix:
         go_version:
-          - 1.15
+          - 1.17
         os:
           - ubuntu-latest
 

--- a/async/go-client/pkg/user.go
+++ b/async/go-client/pkg/user.go
@@ -104,7 +104,6 @@ func (u *UserProvider) CallBack(response common.CallbackResponse) {
 
 	user := resp.Result.(*protocol.RPCResult).Rest.(*User)
 	gxlog.CInfo("async callback response! got result :%v\n", user)
-	return
 }
 
 // UserProviderV2 for one way

--- a/polaris/router/go-client/cmd/main.go
+++ b/polaris/router/go-client/cmd/main.go
@@ -74,8 +74,7 @@ func main() {
 		time.Sleep(200 * time.Millisecond)
 		user, err := userProvider.GetUser(reqContext, &User{Name: "Alex001"})
 		if err != nil {
-			logger.Errorf("error: %v\n", err)
-		} else {
+			panic(err)
 		}
 		logger.Infof("response: %v\n", user)
 	}


### PR DESCRIPTION
The Dubbo-go's integration testing is using Go 1.17. Therefore, the Dubbo-go-samples' Go version should be bumped to 1.17 as well.

Signed-off-by: Xuewei Niu <justxuewei@apache.org>