### PR TITLE
fix: remove same signal

### DIFF
--- a/async/go-server/cmd/server.go
+++ b/async/go-server/cmd/server.go
@@ -63,7 +63,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/context/dubbo/go-server/cmd/server.go
+++ b/context/dubbo/go-server/cmd/server.go
@@ -94,7 +94,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/direct/README.md
+++ b/direct/README.md
@@ -67,7 +67,7 @@ initSignal()
     func initSignal() {
         signals := make(chan os.Signal, 1)
         // It is not possible to block SIGKILL or syscall.SIGSTOP
-        signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+        signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
         for {
             sig := <-signals
             logger.Infof("get signal %s", sig.String())

--- a/direct/README_zh.md
+++ b/direct/README_zh.md
@@ -70,7 +70,7 @@ initSignal()
     func initSignal() {
         signals := make(chan os.Signal, 1)
         // It is not possible to block SIGKILL or syscall.SIGSTOP
-        signal.Notify(signals, os.Interrup, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+        signal.Notify(signals, os.Interrup, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
         for {
             sig := <-signals
             logger.Infof("get signal %s", sig.String())

--- a/error/triple/hessian2/go-server/cmd/server.go
+++ b/error/triple/hessian2/go-server/cmd/server.go
@@ -55,7 +55,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/filter/tpslimit/go-server/cmd/server.go
+++ b/filter/tpslimit/go-server/cmd/server.go
@@ -55,7 +55,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/game/go-server-game/cmd/server.go
+++ b/game/go-server-game/cmd/server.go
@@ -58,7 +58,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %#s", sig.String())

--- a/game/go-server-gate/cmd/server.go
+++ b/game/go-server-gate/cmd/server.go
@@ -65,7 +65,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/generic/default/go-server/cmd/server.go
+++ b/generic/default/go-server/cmd/server.go
@@ -52,7 +52,7 @@ func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP,
-		syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+		syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/polaris/limit/go-server/cmd/server.go
+++ b/polaris/limit/go-server/cmd/server.go
@@ -90,7 +90,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/polaris/registry/go-server/cmd/server.go
+++ b/polaris/registry/go-server/cmd/server.go
@@ -89,7 +89,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/polaris/router/go-server/server-dev/cmd/server.go
+++ b/polaris/router/go-server/server-dev/cmd/server.go
@@ -90,7 +90,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/polaris/router/go-server/server-pre/cmd/server.go
+++ b/polaris/router/go-server/server-pre/cmd/server.go
@@ -90,7 +90,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/polaris/router/go-server/server-prod/cmd/server.go
+++ b/polaris/router/go-server/server-prod/cmd/server.go
@@ -90,7 +90,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/registry/etcd/go-server/cmd/server.go
+++ b/registry/etcd/go-server/cmd/server.go
@@ -56,7 +56,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/registry/nacos/go-server/cmd/server.go
+++ b/registry/nacos/go-server/cmd/server.go
@@ -89,7 +89,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/registry/zookeeper/go-server/cmd/server.go
+++ b/registry/zookeeper/go-server/cmd/server.go
@@ -75,7 +75,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/rpc/dubbo/go-server/cmd/server.go
+++ b/rpc/dubbo/go-server/cmd/server.go
@@ -66,7 +66,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/rpc/grpc/go-server/cmd/server.go
+++ b/rpc/grpc/go-server/cmd/server.go
@@ -62,7 +62,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/rpc/jsonrpc/go-client/cmd/client.go
+++ b/rpc/jsonrpc/go-client/cmd/client.go
@@ -72,7 +72,7 @@ func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP,
-		syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+		syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/rpc/jsonrpc/go-server/cmd/server.go
+++ b/rpc/jsonrpc/go-server/cmd/server.go
@@ -56,7 +56,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/rpc/triple/hessian2/go-server/cmd/server.go
+++ b/rpc/triple/hessian2/go-server/cmd/server.go
@@ -57,7 +57,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/rpc/triple/msgpack/go-server/cmd/server.go
+++ b/rpc/triple/msgpack/go-server/cmd/server.go
@@ -70,7 +70,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/rpc/triple/pb/dubbogo-grpc/go-server/cmd/server.go
+++ b/rpc/triple/pb/dubbogo-grpc/go-server/cmd/server.go
@@ -54,7 +54,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/rpc/triple/pb/dubbogo-java/go-server/cmd/server.go
+++ b/rpc/triple/pb/dubbogo-java/go-server/cmd/server.go
@@ -54,7 +54,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/rpc/triple/pb2/go-server/cmd/server.go
+++ b/rpc/triple/pb2/go-server/cmd/server.go
@@ -51,7 +51,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/seata-go/tcc/server/cmd/server.go
+++ b/seata-go/tcc/server/cmd/server.go
@@ -64,7 +64,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/tls/dubbo/go-server/cmd/server.go
+++ b/tls/dubbo/go-server/cmd/server.go
@@ -66,7 +66,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/tls/grpc/go-server/cmd/server.go
+++ b/tls/grpc/go-server/cmd/server.go
@@ -60,7 +60,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		switch sig {

--- a/tracing/dubbo/go-client/cmd/client.go
+++ b/tracing/dubbo/go-client/cmd/client.go
@@ -79,7 +79,7 @@ func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP,
-		syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+		syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/tracing/dubbo/go-server/cmd/server.go
+++ b/tracing/dubbo/go-server/cmd/server.go
@@ -66,7 +66,7 @@ func main() {
 
 func initSignal() {
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/tracing/grpc/go-client/cmd/client.go
+++ b/tracing/grpc/go-client/cmd/client.go
@@ -81,7 +81,7 @@ func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP,
-		syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+		syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		gxlog.CInfo("get signal %s", sig.String())

--- a/tracing/grpc/go-server/cmd/server.go
+++ b/tracing/grpc/go-server/cmd/server.go
@@ -77,7 +77,7 @@ func main() {
 func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/tracing/jsonrpc/go-client/cmd/client.go
+++ b/tracing/jsonrpc/go-client/cmd/client.go
@@ -77,7 +77,7 @@ func initSignal() {
 	signals := make(chan os.Signal, 1)
 	// It is not possible to block SIGKILL or syscall.SIGSTOP
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP,
-		syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+		syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())

--- a/tracing/jsonrpc/go-server/cmd/server.go
+++ b/tracing/jsonrpc/go-server/cmd/server.go
@@ -63,7 +63,7 @@ func main() {
 
 func initSignal() {
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	for {
 		sig := <-signals
 		logger.Infof("get signal %s", sig.String())


### PR DESCRIPTION
## what

`os.Interrupt` is the same signal as `syscall.SIGINT`.

go code: `/usr/local/go/src/os/exec_posix.go`

```go
// The only signal values guaranteed to be present in the os package on all
// systems are os.Interrupt (send the process an interrupt) and os.Kill (force
// the process to exit). On Windows, sending os.Interrupt to a process with
// os.Process.Signal is not implemented; it will return an error instead of
// sending a signal.
var (
	Interrupt Signal = syscall.SIGINT
	Kill      Signal = syscall.SIGKILL
)

```
