### PR TITLE
fxi service discovery sample

### DIFF
--- a/java_interop/service_discovery/service/java-server/src/main/resources/application.yml
+++ b/java_interop/service_discovery/service/java-server/src/main/resources/application.yml
@@ -18,6 +18,7 @@ dubbo:
   application:
     name: greet-java-server
     logger: slf4j
+    metadataServiceProtocol: dubbo # required, dubbo-go not support tri
   protocol:
     name: tri
     port: 20055


### PR DESCRIPTION
fxi service discovery sample due to dubbo-go not support tri protocol in metadata service