### PR TITLE
fix: Implement MethodMapper with context to resolve TRIPLE param requ…

### DIFF
--- a/compatibility/generic/default/go-server/pkg/user_provider.go
+++ b/compatibility/generic/default/go-server/pkg/user_provider.go
@@ -121,7 +121,7 @@ func (u *UserProvider) QueryAll(_ context.Context) (*UserResponse, error) {
 	}, nil
 }
 
-func (u *UserProvider) MethodMapper() map[string]string {
+func (u *UserProvider) MethodMapper(_ context.Context) map[string]string {
 	return map[string]string{
 		"QueryUser":  "queryUser",
 		"QueryUsers": "queryUsers",

--- a/compatibility/generic/default/go-server/pkg/user_provider_triple.go
+++ b/compatibility/generic/default/go-server/pkg/user_provider_triple.go
@@ -120,7 +120,7 @@ func (u *UserProviderTriple) QueryAll(_ context.Context) (*UserResponse, error) 
 	}, nil
 }
 
-func (u *UserProviderTriple) MethodMapper() map[string]string {
+func (u *UserProviderTriple) MethodMapper(_ context.Context) map[string]string {
 	return map[string]string{
 		"QueryUser":  "queryUser",
 		"QueryUsers": "queryUsers",


### PR DESCRIPTION
…irement

When executing the following command: 
cd ./compatibility/generic/default/go-server/cmd
export DUBBO_GO_CONFIG_PATH="../conf/dubbogo.yml"
go run .

starting the generic Go server, an error occurred as shown in the figure.
![image](https://github.com/user-attachments/assets/f6736a83-4a75-404d-8f3f-b593f9d00497)

The reason is that it does not support generalized calls without parameters.