### PR TITLE
update github actions/cache v3.2.6 to v4.0.0

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4.0.0
 
       - name: Cache dependencies
-        uses: actions/cache@v3.2.6
+        uses: actions/cache@v4.0.0
         with:
           # Cache
           path: ~/go/pkg/mod


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f98c8b5c-18e8-478a-a370-165a460f0f98)
