### PR TITLE
Fix golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         golang:
-          - '1.20'
+          - '1.23'
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -46,9 +46,9 @@ jobs:
           go mod tidy
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.4.0
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.54
+          version: v1.61
           args: --timeout=10m
           skip-go-installation: true
           skip-pkg-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,24 +1,18 @@
 linters-settings:
-  govet:
-    check-shadowing: true
-  golint:
-    min-confidence: 0
   gocyclo:
     min-complexity: 10
-  maligned:
-    suggest-new: true
   dupl:
     threshold: 100
   goconst:
     min-len: 2
     min-occurrences: 2
   depguard:
-    list-type: blacklist
-    packages:
-      # logging is allowed only by logutils.Log, logrus
-      # is allowed to use only in logutils package
-      - github.com/sirupsen/logrus
-  misspell:
+    rules:
+      main:
+        deny:
+          # logging is allowed only by logutils.Log, logrus
+          # is allowed to use only in logutils package
+          - github.com/sirupsen/logrus
     locale: US
   lll:
     line-length: 140
@@ -35,17 +29,14 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - govet
     - staticcheck
     - ineffassign
     - misspell
 
-run:
-  skip-dirs:
+issues:
+  exclude-dirs:
     - test/testdata_etc
     - pkg/golinters/goanalysis/(checker|passes)
-
-issues:
   exclude-rules:
     - text: "weak cryptographic primitive"
       linters:
@@ -54,10 +45,4 @@ issues:
         - staticcheck
       text: "SA1019:"
 
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.15.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters-settings:
           # is allowed to use only in logutils package
           - pkg: "github.com/sirupsen/logrus"
             desc: not allowed
-    locale: US
   lll:
     line-length: 140
   goimports:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,8 @@ linters-settings:
         deny:
           # logging is allowed only by logutils.Log, logrus
           # is allowed to use only in logutils package
-          - github.com/sirupsen/logrus
+          - pkg: "github.com/sirupsen/logrus"
+            desc: not allowed
     locale: US
   lll:
     line-length: 140

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,10 +10,8 @@ linters-settings:
     rules:
       main:
         deny:
-          # logging is allowed only by logutils.Log, logrus
-          # is allowed to use only in logutils package
           - pkg: "github.com/sirupsen/logrus"
-            desc: not allowed
+            desc: logging is allowed only by logutils.Log, logrus, is allowed to use only in logutils package
   lll:
     line-length: 140
   goimports:


### PR DESCRIPTION
**What this PR does:**

Upgrade the golangci-lint version to 1.61 and modify the linter configuration.

**Which issue(s) this PR fixes:**

N/A

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?:**

NONE