### PR TITLE
Make chat history count configurable

### DIFF
--- a/llm/.env.example
+++ b/llm/.env.example
@@ -21,3 +21,4 @@ OLLAMA_URL = http://localhost:11434
 TIME_OUT_SECOND = 300
 
 NACOS_URL = localhost:8848
+MAX_CONTEXT_COUNT = 3

--- a/llm/config/config.go
+++ b/llm/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 
 	TimeoutSeconds int
 	NacosURL       string
+	MaxContextCount int
 }
 
 var (
@@ -94,6 +95,17 @@ func Load(envFile string) (*Config, error) {
 			return
 		}
 		config.NacosURL = nacosURL
+		maxContextStr := os.Getenv("MAX_CONTEXT_COUNT")
+		if maxContextStr == "" {
+			config.MaxContextCount = 3 // Default to 3 for backward compatibility
+		} else {
+			maxContext, err := strconv.Atoi(maxContextStr)
+			if err != nil {
+				configErr = fmt.Errorf("invalid MAX_CONTEXT_COUNT value: %v", err)
+				return
+			}
+			config.MaxContextCount = maxContext
+		}
 	})
 
 	return config, configErr

--- a/llm/go-client/cmd/client.go
+++ b/llm/go-client/cmd/client.go
@@ -48,6 +48,7 @@ var (
 	maxID           uint8 = 0
 	availableModels []string
 	currentModel    string
+	maxContextCount int
 )
 
 func handleCommand(cmd string) (resp string) {
@@ -64,7 +65,7 @@ func handleCommand(cmd string) (resp string) {
 		resp += "/model <name>  - Switch to specified model"
 		return resp
 	case cmd == "/list":
-		fmt.Println("Stored contexts (max 3):")
+		fmt.Println("Stored contexts (max " + fmt.Sprintf("%d", maxContextCount) + "):")
 		for _, ctxID := range contextOrder {
 			resp += fmt.Sprintf("- %s\n", ctxID)
 		}
@@ -124,8 +125,8 @@ func createContext() string {
 	}
 	contextOrder = append(contextOrder, id)
 
-	// up to 3 context
-	if len(contextOrder) > 3 {
+	// Use configurable max context count
+	if len(contextOrder) > maxContextCount {
 		delete(contexts, contextOrder[0])
 		contextOrder = contextOrder[1:]
 	}
@@ -141,6 +142,7 @@ func main() {
 
 	availableModels = cfg.OllamaModels
 	currentModel = cfg.DefaultModel()
+	maxContextCount = cfg.MaxContextCount
 
 	currentCtxID = createContext()
 


### PR DESCRIPTION
## Description
This PR makes the maximum number of chat history records configurable instead of being hard-coded to 3.

Fixes #824 

## Changes
- Added a new `MaxContextCount` field to the `Config` struct
- Added the `MAX_CONTEXT_COUNT` environment variable (defaults to 3 if not provided)
- Updated the client code to use this configurable value instead of the hard-coded value

