### PR TITLE
[llm] use nacos for service discovery

### DIFF
--- a/llm/.env.example
+++ b/llm/.env.example
@@ -16,9 +16,10 @@
 #
 
 
-OLLAMA_MODELS = llava:7b, qwen2.5:7b
+OLLAMA_MODELS= qwen2.5:7b, llava:7b
 OLLAMA_URL = http://localhost:11434
 TIME_OUT_SECOND = 300
 
 NACOS_URL = localhost:8848
 MAX_CONTEXT_COUNT = 3
+MODEL_NAME = qwen2.5:7b

--- a/llm/config/config.go
+++ b/llm/config/config.go
@@ -30,12 +30,12 @@ import (
 )
 
 type Config struct {
-	OllamaModels []string
-	OllamaURL    string
-
+	OllamaModels    []string
+	OllamaURL       string
 	TimeoutSeconds  int
 	NacosURL        string
 	MaxContextCount int
+	ModelName       string
 }
 
 var (
@@ -73,6 +73,22 @@ func Load(envFile string) (*Config, error) {
 
 		config.OllamaModels = modelsList
 
+		modelName := os.Getenv("MODEL_NAME")
+		if modelName != "" {
+			modelValid := false
+			for _, m := range modelsList {
+				if m == modelName {
+					modelValid = true
+					break
+				}
+			}
+			if !modelValid {
+				configErr = fmt.Errorf("specified model %s is not in the configured models list", modelName)
+				return
+			}
+			config.ModelName = modelName
+		}
+
 		ollamaURL := os.Getenv("OLLAMA_URL")
 		if ollamaURL == "" {
 			configErr = fmt.Errorf("OLLAMA_URL is not set")
@@ -94,10 +110,11 @@ func Load(envFile string) (*Config, error) {
 
 		nacosURL := os.Getenv("NACOS_URL")
 		if nacosURL == "" {
-			configErr = fmt.Errorf("OLLAMA_URL is not set")
+			configErr = fmt.Errorf("NACOS_URL is not set")
 			return
 		}
 		config.NacosURL = nacosURL
+
 		maxContextStr := os.Getenv("MAX_CONTEXT_COUNT")
 		if maxContextStr == "" {
 			config.MaxContextCount = defaultMaxContextCount

--- a/llm/go-client/cmd/client.go
+++ b/llm/go-client/cmd/client.go
@@ -20,6 +20,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"dubbo.apache.org/dubbo-go/v3/logger"
 	"fmt"
 	"os"
 	"strings"
@@ -150,6 +151,10 @@ func main() {
 		dubbo.WithRegistry(
 			registry.WithNacos(),
 			registry.WithAddress(cfg.NacosURL),
+		),
+		dubbo.WithLogger(
+			logger.WithLevel("warn"),
+			logger.WithZap(),
 		),
 	)
 	if err != nil {

--- a/llm/go-client/cmd/client.go
+++ b/llm/go-client/cmd/client.go
@@ -20,6 +20,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"dubbo.apache.org/dubbo-go/v3/client"
 	"dubbo.apache.org/dubbo-go/v3/logger"
 	"fmt"
 	"os"
@@ -147,6 +148,7 @@ func main() {
 
 	currentCtxID = createContext()
 
+	// #TODO support selecting model
 	ins, err := dubbo.NewInstance(
 		dubbo.WithRegistry(
 			registry.WithNacos(),
@@ -161,7 +163,9 @@ func main() {
 		panic(err)
 	}
 	// configure the params that only client layer cares
-	cli, err := ins.NewClient()
+	cli, err := ins.NewClient(
+		client.WithClientLoadBalanceRoundRobin(),
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/llm/go-client/frontend/main.go
+++ b/llm/go-client/frontend/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"dubbo.apache.org/dubbo-go/v3/client"
 	"fmt"
 	"net/http"
 )
@@ -57,7 +58,9 @@ func main() {
 		panic(err)
 	}
 	// configure the params that only client layer cares
-	cli, err := ins.NewClient()
+	cli, err := ins.NewClient(
+		client.WithClientLoadBalanceRoundRobin(),
+	)
 
 	if err != nil {
 		panic(fmt.Sprintf("Error creating Dubbo client: %v", err))

--- a/llm/start_servers.bat
+++ b/llm/start_servers.bat
@@ -1,0 +1,68 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Default values
+set START_PORT=20020
+set INSTANCES_PER_MODEL=2
+
+REM Parse command line arguments
+:parse_args
+if "%~1"=="" goto :end_parse
+if "%~1"=="--instances" (
+    set INSTANCES_PER_MODEL=%~2
+    shift
+    shift
+    goto :parse_args
+)
+if "%~1"=="--start-port" (
+    set START_PORT=%~2
+    shift
+    shift
+    goto :parse_args
+)
+:end_parse
+
+REM Check if .env file exists
+if not exist .env (
+    echo Error: .env file not found
+    exit /b 1
+)
+
+REM Read and clean OLLAMA_MODELS from .env file
+for /f "usebackq tokens=*" %%a in (`powershell -Command "Get-Content .env | Select-String '^[[:space:]]*OLLAMA_MODELS[[:space:]]*=' | ForEach-Object { $_.Line -replace '^[^=]*=[[:space:]]*', '' -replace '^[\"'']+|[\"'']+$', '' }"`) do (
+    set MODELS_LINE=%%a
+)
+
+if "!MODELS_LINE!"=="" (
+    echo Error: OLLAMA_MODELS not found in .env file
+    echo Please make sure .env file contains a line like: OLLAMA_MODELS = llava:7b, qwen2.5:7b
+    exit /b 1
+)
+
+echo Found models: !MODELS_LINE!
+
+REM Split models and start servers
+set current_port=%START_PORT%
+
+for %%m in (!MODELS_LINE:,=^,!) do (
+    set "model=%%m"
+    set "model=!model: =!"
+    echo Processing model: !model!
+    
+    for /l %%i in (1,1,%INSTANCES_PER_MODEL%) do (
+        echo Starting server for model: !model! (Instance %%i, Port: !current_port!)
+        set MODEL_NAME=!model!
+        set SERVER_PORT=!current_port!
+        start /B cmd /c "go run go-server/cmd/server.go"
+        timeout /t 2 /nobreak >nul
+        set /a current_port+=1
+    )
+)
+
+set /a total_instances=0
+for %%a in (!MODELS_LINE:,=^,!) do set /a total_instances+=1
+set /a total_instances*=%INSTANCES_PER_MODEL%
+
+echo All servers started. Total instances: !total_instances!
+echo Use Ctrl+C to stop all servers.
+pause 

--- a/llm/start_servers.sh
+++ b/llm/start_servers.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Check if .env file exists
+if [ ! -f .env ]; then
+    echo "Error: .env file not found"
+    exit 1
+fi
+
+# Default values
+START_PORT=20020
+INSTANCES_PER_MODEL=2
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --instances)
+            INSTANCES_PER_MODEL=$2
+            shift 2
+            ;;
+        --start-port)
+            START_PORT=$2
+            shift 2
+            ;;
+        *)
+            echo "Unknown parameter: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Function to read value from .env file and clean it
+get_env_value() {
+    local key=$1
+    # Read the line containing the key, extract everything after the first =
+    local value=$(grep "^[[:space:]]*$key[[:space:]]*=" .env | sed 's/^[^=]*=[[:space:]]*//')
+    # Remove leading/trailing whitespace and quotes
+    value=$(echo "$value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/^["\x27]//' -e 's/["\x27]$//')
+    echo "$value"
+}
+
+# Get models from .env file
+OLLAMA_MODELS=$(get_env_value "OLLAMA_MODELS")
+
+# Check if OLLAMA_MODELS is empty
+if [ -z "$OLLAMA_MODELS" ]; then
+    echo "Error: OLLAMA_MODELS not found in .env file"
+    echo "Please make sure .env file contains a line like: OLLAMA_MODELS = llava:7b, qwen2.5:7b"
+    exit 1
+fi
+
+echo "Found models: $OLLAMA_MODELS"
+
+# Convert comma-separated string to array, handling spaces
+IFS=',' read -ra MODELS <<< "$OLLAMA_MODELS"
+
+current_port=$START_PORT
+
+# Function to start a model instance
+start_model_instance() {
+    local model=$1
+    local port=$2
+    local instance_num=$3
+    
+    # Clean the model name (remove leading/trailing spaces)
+    model=$(echo "$model" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    
+    echo "Starting server for model: $model (Instance $instance_num, Port: $port)"
+    export MODEL_NAME=$model
+    export SERVER_PORT=$port
+    go run go-server/cmd/server.go &
+    sleep 2
+}
+
+# Start instances for each model
+for model in "${MODELS[@]}"; do
+    echo "Processing model: $model"
+    for ((i=1; i<=INSTANCES_PER_MODEL; i++)); do
+        start_model_instance "$model" $current_port $i
+        ((current_port++))
+    done
+done
+
+echo "All servers started. Total instances: $((${#MODELS[@]} * INSTANCES_PER_MODEL))"
+echo "Use Ctrl+C to stop all servers."
+
+# Wait for all background processes
+wait 


### PR DESCRIPTION
1. Each server is aligned with one LLM.
2. Use a script to run the server cluster and use Nacos for service discovery.
3. Load balancing is implemented using round-robin, but it currently does not support selecting models.
4. change client logger level to warn
5. update README