### PR TITLE
optimize: remove version:3 of docker-compose.yml

### DIFF
--- a/integrate_test/dockercompose/docker-compose.yml
+++ b/integrate_test/dockercompose/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # services config in one docker-compose file for integrate test
 # integrate test will start up services and samples test will depend on those containers
 services:


### PR DESCRIPTION
#### What this PR does / Why we need it

##### Description：

According to the latest Docker Compose specification, the top-level version key is deprecated and no longer required.

Modern versions of Docker Compose now default to the [Compose Specification](https://www.google.com/search?q=https://github.com/compose-spec/compose-spec/blob/master/spec.md) and will ignore this legacy key. Removing it simplifies the docker-compose.yml file and aligns it with current best practices.

This commit removes the redundant version: '3' declaration to optimize the configuration.