### PR TITLE
fix: polaris limit test would fail in current ratelimit logic

### DIFF
--- a/compatibility/polaris/limit/README-zh.md
+++ b/compatibility/polaris/limit/README-zh.md
@@ -42,6 +42,8 @@ dubbo:
 
 dubbogo 中的 PolarisMesh TpsLimiter 扩展点实现，能够根据用户配置的限流规则，自动的从当前 RPC 调用上下文以及请求信息中识别出需要参与限流的请求标签信息
 
+请根据以下图片配置限流策略
+
 ![](images/dubbogo-ratelimit-rule.png)
 
 - 请求匹配规则为 **请求参数(QUERY)**

--- a/compatibility/polaris/limit/README.md
+++ b/compatibility/polaris/limit/README.md
@@ -42,6 +42,8 @@ Note: The service current limiting capability of PolarisMesh works on the Provid
 
 The implementation of the PolarisMesh TpsLimiter extension point in dubbogo can automatically identify the request tag information that needs to participate in current limiting from the current RPC call context and request information according to the current limiting rules configured by the user.
 
+Please config the ratelimit strategy according to the picture.
+
 ![](images/dubbogo-ratelimit-rule.png)
 
 - The request matching rule is **Request parameter(QUERY)**

--- a/compatibility/polaris/limit/go-client/cmd/main.go
+++ b/compatibility/polaris/limit/go-client/cmd/main.go
@@ -67,14 +67,17 @@ func main() {
 	var successCount, failCount int64
 	for i := 0; i < 10; i++ {
 		time.Sleep(50 * time.Millisecond)
-		user, err := userProvider.GetUser(context.TODO(), &User{Name: "Alex03"})
+		user, err := userProvider.GetUser(context.TODO(), &User{Name: "Alex001"})
 		if err != nil {
-			failCount++
 			logger.Infof("error: %v\n", err)
-		} else {
-			successCount++
 		}
-		logger.Infof("response: %v\n", user)
+		if user.ID == "A001" && user.Age == 18 {
+			successCount++
+			logger.Infof("response success: %v\n", user)
+		} else {
+			failCount++
+			logger.Infof("response fail: %v\n", user)
+		}
 	}
 	logger.Infof("successCount=%v, failCount=%v\n", successCount, failCount)
 


### PR DESCRIPTION
Current ratelimit would return a empty result to consumer instead of return an error on fail, this pr fix the check logic of ratelimit fail.