### PR TITLE
fix: image router problem #1078

### DIFF
--- a/router/polaris/README.md
+++ b/router/polaris/README.md
@@ -20,7 +20,7 @@ Quickly experience Polaris' service routing capabilities in dubbogo
 
 The implementation of the PolarisMesh PriorityRouter extension point in dubbogo can automatically identify the request label information that needs to participate in service routing from the current RPC call context and request information according to the service route rules configured by the user.
 
-![](images/dubbogo-route-rule.png)
+![](image/dubbogo-route-rule.png)
 
 ### Running the service provider
 

--- a/router/polaris/README_zh.md
+++ b/router/polaris/README_zh.md
@@ -20,7 +20,7 @@
 
 dubbogo 中的 PolarisMesh PriorityRouter 扩展点实现，能够根据用户配置的服务路由规则，自动的从当前 RPC 调用上下文以及请求信息中识别出需要参与服务路由的请求标签信息。
 
-![](images/dubbogo-route-rule.png)
+![](image/dubbogo-route-rule.png)
 
 ### 运行服务提供者
 

--- a/router/tag/README_CN.md
+++ b/router/tag/README_CN.md
@@ -16,7 +16,7 @@
 
 ```shell
 $ go run ./go-server/cmd/server.go          # 无标签server
-$ go run ./go-tag-server/cmdserver_tag.go   # 有标签server
+$ go run ./go-tag-server/cmd/server_tag.go   # 有标签server
 ```
 
 ### 运行客户端（Consumer）


### PR DESCRIPTION
#1078 
1. I executed the Polaris example without finding any issues
2. Some path-related issues have been resolved
3. Some path-related annotations were ignored by the AI, so an error was reported during execution

<img width="884" height="120" alt="Image" src="https://github.com/user-attachments/assets/2c49488a-54bd-4b02-83d4-329ada08ef70" />