### PR TITLE
fix: In the Java interop sample, Java -> Go fails or is incomplete in…

### DIFF
--- a/java_interop/protobuf-triple/java-server/src/main/java/org/apache/dubbo/sample/Provider.java
+++ b/java_interop/protobuf-triple/java-server/src/main/java/org/apache/dubbo/sample/Provider.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
 public class Provider {
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, InterruptedException {
         ServiceConfig<Greeter> service =  new ServiceConfig<>();
         service.setInterface(Greeter.class);
         service.setRef(new GreeterImpl());

--- a/java_interop/service_discovery/interface/java-client/src/main/resources/log4j2.xml
+++ b/java_interop/service_discovery/interface/java-client/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" shutdownHook="disable">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="error">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/java_interop/service_discovery/service/java-client/src/main/resources/log4j2.xml
+++ b/java_interop/service_discovery/service/java-client/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" shutdownHook="disable">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="error">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
#1074 
1. num1, 2：None of the above error reports were reproduced. Please provide a more detailed reproduction method
2. The java service compilation exception has been resolved
3. num4, 5. mvn exec:java's classloader conflicts with Log4j shutdown hook during the process exit phase. （Attempting to update the version log4j2 was ineffective）. So, Add the log4j2 configuration to eliminate the error message