### PR TITLE
fix(llm): use generic model fields in frontend instead of OllamaModels

### DIFF
--- a/llm/go-client/frontend/main.go
+++ b/llm/go-client/frontend/main.go
@@ -91,8 +91,8 @@ func main() {
 	r.GET("/", func(c *gin.Context) {
 		c.HTML(http.StatusOK, "index.html", gin.H{
 			"TimeoutSecond": cfg.TimeoutSeconds,
-			"OllamaModels":  cfg.OllamaModels,
-			"DefaultModel":  cfg.OllamaModels[0],
+			"Models":        cfg.LLMModelsList,
+			"DefaultModel":  cfg.ModelName,
 		})
 	})
 	r.POST("/api/chat", h.Chat)

--- a/llm/go-client/frontend/templates/index.html
+++ b/llm/go-client/frontend/templates/index.html
@@ -21,8 +21,8 @@
       <h2>LLM Chat</h2>
       <div class="model-selector">
         <label for="model-select"></label><select id="model-select">
-          {{range .OllamaModels}}
-          <option value="{{.}}">{{.}}</option>
+          {{range .Models}}
+          <option value="{{.}}" {{if eq . $.DefaultModel}}selected{{end}}>{{.}}</option>
           {{end}}
         </select>
       </div>


### PR DESCRIPTION
# 修复：非 Ollama 提供商导致前端首页访问 panic

## 问题

当 `LLM_PROVIDER` 不是 `ollama` 时（例如通过 OpenAI 兼容接口使用 openai、gemini），打开前端首页会触发 panic：

```
runtime error: index out of range [0] with length 0
```

错误堆栈指向 `llm/go-client/frontend/main.go`：

```go
"DefaultModel": cfg.OllamaModels[0],
```

## 根本原因

`config.go` 仅在 LLM 提供商为 `ollama` 时才会填充 `OllamaModels`：

```go
if config.LLMProvider == "ollama" {
    config.OllamaModels = modelsList
}
```

因此对于其他提供商，该切片为空，访问索引 `[0]` 会触发 panic。

CLI 已经使用通用的 `cfg.LLMModelsList` 和 `cfg.ModelName`，前端部分未同步适配。

## 修复方案

- `main.go`：将 `cfg.LLMModelsList` 作为 `Models` 传入，`cfg.ModelName` 作为 `DefaultModel` 传入
- `index.html`：遍历 `.Models`，将配置的 `MODEL_NAME` 标记为 `selected`，确保初始下拉框与用户 `.env` 中的配置匹配

## 验证

使用 #1072 中的复现配置进行本地测试：

```
LLM_PROVIDER = openai
LLM_MODELS = gemini-2.5-flash
LLM_BASE_URL = https://generativelanguage.googleapis.com/v1beta/openai/
MODEL_NAME = gemini-2.5-flash
```

- `GET /` 返回 HTTP **200**，无 panic
- 下拉框渲染正常：`<option value="gemini-2.5-flash" selected>gemini-2.5-flash</option>`


<img width="991" height="1108" alt="image" src="https://github.com/user-attachments/assets/0df5c41d-23e8-49a4-9b7c-744307ece70f" />


Ollama 路径不受影响：`LLMModelsList` 和 `ModelName` 在 `config.go` 中对所有 provider 都会填充，因此当 provider 是 ollama 时，渲染结果与原来用 `OllamaModels` 完全一致，无回归。

Closes #1072
