### PR TITLE
 docs(config_center/zookeeper): align README and comments with actual code (#1081, #1082, #1084)

### DIFF
--- a/config_center/zookeeper/README.md
+++ b/config_center/zookeeper/README.md
@@ -5,11 +5,17 @@
 This example shows dubbo-go's dynamic configuration feature with Zookeeper as config-center.
 
 ## 2. How to run
-### Run the following commands under `repo root`:
+
+### Start a Zookeeper instance
+
+Make sure a Zookeeper instance is listening on `127.0.0.1:2181`. The simplest way is to start one with Docker:
 
 ```
-docker compose up -d zookeeper
+docker run -d --name zookeeper -p 2181:2181 zookeeper:3.8
 ```
+
+Or follow the [Zookeeper installation guide](https://zookeeper.apache.org/doc/current/zookeeperStarted.html) to install it locally.
+
 ### Configure the configuration file into zookeeper
 
 ```yaml
@@ -22,7 +28,7 @@ dubbo:
   protocols:
     triple:
       name: tri
-      port: 20000
+      port: 50000
   provider:
     services:
       GreeterProvider:
@@ -36,7 +42,7 @@ If there is no preexisting configuration, that is fine as well, because the samp
 
 ```go
 zkOption := config_center.WithZookeeper()
-dataIdOption := config_center.WithDataID("dubbo-go-samples-configcenter-zookeeper-server")
+dataIdOption := config_center.WithDataID("dubbo-go-samples-configcenter-zookeeper-go-server")
 addressOption := config_center.WithAddress("127.0.0.1:2181")
 groupOption := config_center.WithGroup("dubbogo")
 ins, err := dubbo.NewInstance(

--- a/config_center/zookeeper/README_zh.md
+++ b/config_center/zookeeper/README_zh.md
@@ -5,10 +5,17 @@
 本示例演示Dubbo-Go以ZooKeeper为配置中心来实现动态配置功能
 
 ## 2. 如何运行
-### 在 `仓库根目录` 目录下执行：
+
+### 启动 Zookeeper 实例
+
+确保有一个 Zookeeper 实例监听在 `127.0.0.1:2181`。最简单的方式是用 Docker 启动一个：
+
 ```
-docker compose up -d zookeeper
+docker run -d --name zookeeper -p 2181:2181 zookeeper:3.8
 ```
+
+或者参考 [Zookeeper 安装文档](https://zookeeper.apache.org/doc/current/zookeeperStarted.html) 在本地安装。
+
 ### 把配置文件配置到zookeeper中
 
 ```yaml
@@ -21,7 +28,7 @@ dubbo:
   protocols:
     triple:
       name: tri
-      port: 20000
+      port: 50000
   provider:
     services:
       GreeterProvider:
@@ -35,7 +42,7 @@ dubbo:
 
 ```go
 zkOption := config_center.WithZookeeper()
-dataIdOption := config_center.WithDataID("dubbo-go-samples-configcenter-zookeeper-server")
+dataIdOption := config_center.WithDataID("dubbo-go-samples-configcenter-zookeeper-go-server")
 addressOption := config_center.WithAddress("127.0.0.1:2181")
 groupOption := config_center.WithGroup("dubbogo")
 ins, err := dubbo.NewInstance(

--- a/config_center/zookeeper/go-server/cmd/main.go
+++ b/config_center/zookeeper/go-server/cmd/main.go
@@ -87,7 +87,7 @@ func main() {
 	}
 }
 
-const configCenterZKServerConfig = `## set in config center, group is 'dubbogo', dataid is 'dubbo-go-samples-configcenter-zookeeper-server', namespace is default
+const configCenterZKServerConfig = `## set in config center, group is 'dubbogo', dataid is 'dubbo-go-samples-configcenter-zookeeper-go-server', namespace is default
 dubbo:
   registries:
     demoZK:


### PR DESCRIPTION
 ## 修复内容                                                                                                                                       

  修复 `config_center/zookeeper` sample 中三处文档与代码不一致的问题：                                                                                 
  1. **#1081 — Triple 端口**                                                                                                                        
     README 写 `port: 20000`，但 `go-server/cmd/main.go` 中推送到 ZooKeeper 的 YAML 实际使用 `port: 50000`。服务端实际监听 50000，因此把 README
  改为与代码一致。

  2. **#1082 — DataID**
     README 和 main.go 内联注释都写 `dubbo-go-samples-configcenter-zookeeper-server`，但实际 `WithDataID()` 调用以及 ZooKeeper 路径用的是
  `dubbo-go-samples-configcenter-zookeeper-go-server`（多了 `-go-`）。把文档改为与代码一致。

  3. **#1084 — Zookeeper 启动命令**
     README 写的是 `docker compose up -d zookeeper`，但仓库里并没有对应的 compose 文件，按文档操作会失败。改为具体的 `docker run` 命令，并附        
  Zookeeper 官方安装文档链接。

  `README.md` 和 `README_zh.md` 同步更新。

  ## 验证

  ```bash
  go build ./config_center/zookeeper/...   # 编译通过

  只动文档和一处内联注释，无代码逻辑改动。

  Closes #1081
  Closes #1082
  Closes #1084
