### PR TITLE
 docs(book-flight-ai-agent): 修复 README 中 frntend → frontend 拼写错误 (#1080)

### DIFF
--- a/book-flight-ai-agent/README.md
+++ b/book-flight-ai-agent/README.md
@@ -50,7 +50,7 @@ $ go run go-server/cmd/server.go
 The front-end page interacts with the client based on the Gin framework. Run the following command and then visit ```localhost:8080``` to use it:
 
 ```shell
-$ go run go-client/frntend/main.go
+$ go run go-client/frontend/main.go
 ```
 
 ### **Notes**

--- a/book-flight-ai-agent/README_zh.md
+++ b/book-flight-ai-agent/README_zh.md
@@ -50,7 +50,7 @@ $ go run go-server/cmd/server.go
 前端页面基于 Gin 框架的客户端进行交互，运行以下命令然后访问 ```localhost:8080``` 即可使用:
 
 ```shell
-$ go run go-client/frntend/main.go
+$ go run go-client/frontend/main.go
 ```
 
 ### **注意事项**


### PR DESCRIPTION
## 修复内容

  `book-flight-ai-agent/README.md` 和 `README_zh.md` 第 53 行将前端启动命令写成了：

  ```shell
  $ go run go-client/frntend/main.go
  ```

  但实际目录是 `go-client/frontend/`（少了一个字母 `o`）。新用户照着文档复制粘贴会得到 `directory does not exist` 报错。

  中英文 README 同步修正。

  Closes #1080
