### PR TITLE
 fix(apisix): 给 nacos 容器加 container_name 让示例可开箱跑通 (#1079)

### DIFF
--- a/apisix/deploy/nacos2.0.3-compose/docker-compose.yml
+++ b/apisix/deploy/nacos2.0.3-compose/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3"
 services:
   nacos:
+    container_name: nacos
     image: nacos/nacos-server:v2.2.3
     environment:
       - PREFER_HOST_MODE=hostname


### PR DESCRIPTION
  ## 问题

  APISIX 配置 `apisix/deploy/apisix-compose/apisix_conf/config.yaml` 用 hostname `nacos` 做服务发现：

  ```yaml
  discovery:
    nacos:
      host:
        - "http://nacos:8848"
  ```

  README 第 75 行也用 `docker inspect ... nacos` 取容器 IP。两处都假设容器名是 `nacos`。

  但 `nacos2.0.3-compose/docker-compose.yml` 没设置 `container_name`，`docker compose up` 会生成名字 `nacos203-compose-nacos-1`，导致：

  - APISIX 解析不到 `nacos`，报一个让人摸不着头脑的 Lua 错误：

    ```
    nacos/init.lua:361: attempt to index upvalue 'applications' (a nil value)
    ```

  - README 里的 `docker inspect ... nacos` 也找不到容器。

  新用户照着 README 跑必然踩坑。

  ## 修复

  给 nacos service 加 `container_name: nacos`，让实际部署与文档/APISIX 配置一致：

  ```diff
   services:
     nacos:
  +    container_name: nacos
       image: nacos/nacos-server:v2.2.3
  ```

  ## 验证

  本地按 README 步骤跑通整个 apisix 示例：

  ```bash
  $ curl 'http://127.0.0.1:80/helloworld?name=World'
  {"age":21,"name":"Hello World","id":"12345"}
  ```

  只新增了 1 行配置，无其他改动。

  Closes #1079
