### PR TITLE
 docs(config_yaml): 明确 DUBBO_GO_CONFIG_PATH 路径解析方式 (#1083)

### DIFF
--- a/config_yaml/README.md
+++ b/config_yaml/README.md
@@ -31,15 +31,38 @@ cd path_to_dubbogo-sample/config_yaml/proto
 protoc --go_out=. --go-triple_out=. ./greet.proto
 ```
 ### Server
+
+Run from the repository root:
+
 ```bash
+export DUBBO_GO_CONFIG_PATH="$(pwd)/config_yaml/go-server/conf/dubbogo.yml"
+go run ./config_yaml/go-server/cmd/main.go
+```
+
+Or, if you prefer to `cd` into the `cmd` directory first, the relative path also works:
+
+```bash
+cd config_yaml/go-server/cmd
 export DUBBO_GO_CONFIG_PATH="../conf/dubbogo.yml"
-cd path_to_dubbogo-sample/config_yaml/go-server/cmd
 go run .
 ```
+
+> **Note**: `DUBBO_GO_CONFIG_PATH` is resolved against the working directory of the running process, so a relative value like `../conf/dubbogo.yml` only works when you launch the program from the `cmd` directory. Use an absolute path (as in the first example) to avoid this constraint.
+
 ### Client
+
+Run from the repository root (after the server is up):
+
 ```bash
+export DUBBO_GO_CONFIG_PATH="$(pwd)/config_yaml/go-client/conf/dubbogo.yml"
+go run ./config_yaml/go-client/cmd/main.go
+```
+
+Or, with `cd`:
+
+```bash
+cd config_yaml/go-client/cmd
 export DUBBO_GO_CONFIG_PATH="../conf/dubbogo.yml"
-cd path_to_dubbogo-sample/config_yaml/go-client/cmd
 go run .
 ```
 

--- a/config_yaml/README_zh.md
+++ b/config_yaml/README_zh.md
@@ -32,15 +32,38 @@ cd path_to_dubbogo-sample/config_yaml/proto
 protoc --go_out=. --go-triple_out=. ./greet.proto
 ```
 ### Server
+
+在仓库根目录下运行：
+
 ```bash
+export DUBBO_GO_CONFIG_PATH="$(pwd)/config_yaml/go-server/conf/dubbogo.yml"
+go run ./config_yaml/go-server/cmd/main.go
+```
+
+或者，先 `cd` 到 `cmd` 目录再运行（用相对路径也可以）：
+
+```bash
+cd config_yaml/go-server/cmd
 export DUBBO_GO_CONFIG_PATH="../conf/dubbogo.yml"
-cd path_to_dubbogo-sample/config_yaml/go-server/cmd
 go run .
 ```
+
+> **注意**：`DUBBO_GO_CONFIG_PATH` 是相对于程序运行时的工作目录解析的，所以 `../conf/dubbogo.yml` 这种相对路径只有在 `cmd` 目录下启动程序时才有效。如果想从其他目录启动，建议使用上面那种绝对路径。
+
 ### Client
+
+在仓库根目录下运行（服务端启动后）：
+
 ```bash
+export DUBBO_GO_CONFIG_PATH="$(pwd)/config_yaml/go-client/conf/dubbogo.yml"
+go run ./config_yaml/go-client/cmd/main.go
+```
+
+或者先 `cd`：
+
+```bash
+cd config_yaml/go-client/cmd
 export DUBBO_GO_CONFIG_PATH="../conf/dubbogo.yml"
-cd path_to_dubbogo-sample/config_yaml/go-client/cmd
 go run .
 ```
 


### PR DESCRIPTION
## 问题

  `DUBBO_GO_CONFIG_PATH` 是相对于**程序运行时的工作目录**解析的，但 README 只给了相对路径形式 `../conf/dubbogo.yml`，要求用户 `cd` 进 `cmd`
  目录才能跑通。

  更符合 Go 习惯的命令是从仓库根目录直接跑：

  ```bash
  go run ./config_yaml/go-server/cmd/main.go
  ```

  但这样跑相对路径解析不到 `dubbogo.yml`，`dubbo.Load()` 直接 panic，文档里也没解释原因，新用户很容易卡住。

  ## 修复

  更新中英文 README：

  - **推荐**：从仓库根目录运行 + 用 `$(pwd)/...` 构造绝对路径，无论用户在哪个目录都能工作。
  - 保留原来的 `cd` + 相对路径作为备选方案。
  - 加一段说明，解释 `DUBBO_GO_CONFIG_PATH` 是怎么解析的，方便用户自查。

  ## 验证

  只改文档，无代码改动；编译/运行行为不变，只是文档更准确。

  Closes #1083
