### PR TITLE
fix(book-flight-ai-agent): 使用 reflect.Pointer 满足 govet inline 检查

### DIFF
--- a/book-flight-ai-agent/go-server/tools/tool_base.go
+++ b/book-flight-ai-agent/go-server/tools/tool_base.go
@@ -61,7 +61,7 @@ func scanStructKeys(obj interface{}) string {
 	}
 
 	t := reflect.TypeOf(obj)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		// If it is a pointer, get the value it points to
 		t = t.Elem()
 	}


### PR DESCRIPTION
## 背景

  `book-flight-ai-agent/go-server/tools/tool_base.go:64` 使用了 `reflect.Ptr`：

  ```go
  if t.Kind() == reflect.Ptr {
  ```

  `reflect.Ptr` 是 `reflect.Pointer` 的 **deprecated alias**（Go 1.18 引入 `Pointer` 后 `Ptr` 保留作为兼容别名）。两者运行时完全等价。

  ## 问题

  最近 `golangci-lint` 在 govet 中启用了 `inline` 分析器，它会把 `reflect.Ptr` 标记为：

  ```
  inline: Constant reflect.Ptr should be inlined (govet)

  这一行最初由 commit 6c49cca8c（2025-05-15）引入，但本仓库在 PR #1054（2026-03-16）把 CI 的 golangci-lint 升级到 version: latest 之后，新版 latest 
  才开始 flag 它。导致所有未触及该文件的 PR 也会因这个无关问题挂掉 lint 检查，阻塞合并。

  修复

  把 reflect.Ptr 替换为 reflect.Pointer：

  ```diff
  - if t.Kind() == reflect.Ptr {
  - if t.Kind() == reflect.Pointer {
  ```

  - 运行行为 完全一致（同一个常量值的两个名字）
  - 移除 govet 警告，解锁后续 PR

 对应golang文档refrence

  - https://pkg.go.dev/reflect#Pointer
  - https://pkg.go.dev/reflect#Ptr


