### PR TITLE
fix(book-flight-ai-agent): 前端 / 路由接入 ChatHandler.Index 修复 Set-Cookie 不下发问题 (#1086)

### DIFF
--- a/book-flight-ai-agent/go-client/frontend/handlers/chat.go
+++ b/book-flight-ai-agent/go-client/frontend/handlers/chat.go
@@ -57,11 +57,16 @@ func (h *ChatHandler) Index(c *gin.Context) {
 	if ctxID == nil {
 		ctxID = h.ctxManager.CreateContext()
 		session.Set("current_context", ctxID)
-		session.Save()
+		if err := session.Save(); err != nil {
+			log.Printf("Failed to save session: %v", err)
+		}
 	}
 
+	cfgEnv := conf.GetEnvironment()
 	c.HTML(http.StatusOK, "index.html", gin.H{
-		"title": "LLM Chat",
+		"title":         "LLM Chat",
+		"TimeoutSecond": cfgEnv.TimeOut,
+		"OllamaModel":   cfgEnv.Model,
 	})
 }
 

--- a/book-flight-ai-agent/go-client/frontend/main.go
+++ b/book-flight-ai-agent/go-client/frontend/main.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 )
 
 import (
@@ -72,14 +71,8 @@ func main() {
 	ctxManager := service.NewContextManager()
 
 	// register route
-	cfgEnv := conf.GetEnvironment()
 	h := handlers.NewChatHandler(svc, ctxManager)
-	r.GET("/", func(c *gin.Context) {
-		c.HTML(http.StatusOK, "index.html", gin.H{
-			"TimeoutSecond": cfgEnv.TimeOut,
-			"OllamaModel":   cfgEnv.Model,
-		})
-	})
+	r.GET("/", h.Index)
 	r.POST("/api/chat", h.Chat)
 	r.POST("/api/context/new", h.NewContext)
 	r.GET("/api/context/list", h.ListContexts)


### PR DESCRIPTION
## 问题

  `go-client/frontend/main.go` 把 `/` 路由注册成一个**匿名函数**，它只渲染模板、根本没碰 session：

  ```go
  r.GET("/", func(c *gin.Context) {
      c.HTML(http.StatusOK, "index.html", gin.H{
          "TimeoutSecond": cfgEnv.TimeOut,
          "OllamaModel":   cfgEnv.Model,
      })
  })
  ```

  而 `handlers/chat.go` 里**真正做 session 处理**的 `ChatHandler.Index` 方法从未被注册到任何路由，是死代码。

  后果：

  - `GET /` 响应**没有 Set-Cookie 头**
  - 每次请求 session 里都拿不到 `current_context`，handler 在 `Chat` / `ListContexts` 等地方继续 `CreateContext()`，`ContextManager.Contexts`       
  无上限增长
  - 浏览器刷新一次就丢一次会话历史

  ## 修复

  - `main.go`：把 `/` 路由改成 `r.GET("/", h.Index)`，删掉重复的匿名函数和不再使用的 `net/http` import
  - `handlers/chat.go::Index`：把 `TimeoutSecond` / `OllamaModel` 模板变量补回来（保持页面行为不变），同时给 `session.Save()`
  加上错误日志（之前是静默忽略）

  ## 验证

  本地启动 server + frontend 后实测：

  ```bash
  $ curl -s -i http://127.0.0.1:8080/ | grep Set-Cookie
  Set-Cookie: llm_session=MTc3Nzg5OTc1Nnx...; Path=/; Max-Age=2592000

  # 用同一份 cookie 连续请求 3 次
  $ curl -s -b cookies.txt http://127.0.0.1:8080/api/context/list
  {"contexts":["0"],"current":"0"}
  ```

  修复前同样的 3 次请求会创建 3 个 context；修复后始终只有 1 个，会话语义正确。

  Closes #1086

  ---
