### PR TITLE
docs(apisix): 从快速开始里去掉 MySQL，说明 Derby 默认配置 (#1087)

### DIFF
--- a/apisix/README.md
+++ b/apisix/README.md
@@ -37,19 +37,12 @@ docker network create default_network
 
 ### 2. Start Dependencies
 
-Start etcd, MySQL, Nacos, and APISIX in order:
+Start etcd, Nacos, and APISIX in order:
 
 ```bash
 # Start etcd (APISIX configuration center)
 cd ./deploy/etcd-compose
 docker compose up -d
-
-# Start MySQL (Nacos database)
-cd ../mysql5.7-compose
-docker compose up -d
-
-# Wait for MySQL to be ready (~10 seconds)
-sleep 10
 
 # Start Nacos
 cd ../nacos2.0.3-compose
@@ -64,6 +57,8 @@ docker compose up -d
 
 cd ../../
 ```
+
+> **Note**: This sample runs Nacos in standalone mode with embedded Derby (`SPRING_DATASOURCE_PLATFORM=derby` in `nacos2.0.3-compose/docker-compose.yml`), so **no external MySQL is required for the demo**. A `mysql5.7-compose` directory is kept for users who want a production-like setup; to enable it, start the MySQL compose first and uncomment the MySQL-related env vars in the Nacos compose file.
 
 ### 3. Build and Start Dubbo-Go Service
 

--- a/apisix/README_zh.md
+++ b/apisix/README_zh.md
@@ -37,19 +37,12 @@ docker network create default_network
 
 ### 2. 启动依赖服务
 
-按顺序启动 etcd、MySQL、Nacos 和 APISIX：
+按顺序启动 etcd、Nacos 和 APISIX：
 
 ```bash
 # 启动 etcd (APISIX 的配置中心)
 cd ./deploy/etcd-compose
 docker compose up -d
-
-# 启动 MySQL (Nacos 的数据库)
-cd ../mysql5.7-compose
-docker compose up -d
-
-# 等待 MySQL 启动完成 (约10秒)
-sleep 10
 
 # 启动 Nacos
 cd ../nacos2.0.3-compose
@@ -64,6 +57,8 @@ docker compose up -d
 
 cd ../../
 ```
+
+> **说明**：本示例的 Nacos 以 standalone 模式运行，使用内嵌 Derby（见 `nacos2.0.3-compose/docker-compose.yml` 中的 `SPRING_DATASOURCE_PLATFORM=derby`），**演示场景下无需启动外部 MySQL**。仓库里仍保留 `mysql5.7-compose` 目录，供希望使用生产级持久化的用户参考；如需启用，先用该目录的 compose 启动 MySQL，再在 Nacos 的 compose 里取消注释 MySQL 相关的环境变量即可。
 
 ### 3. 构建并启动 Dubbo-Go 服务
 


### PR DESCRIPTION
## 问题

  `nacos2.0.3-compose/docker-compose.yml` 里设置的是 `SPRING_DATASOURCE_PLATFORM=derby`，MySQL
  相关环境变量都是注释状态。所以在示例的运行路径下，Nacos 用的是**内嵌 Derby**，**完全不连 MySQL**。

  但 README 仍然让用户：

  ```bash
  # 启动 MySQL (Nacos 的数据库)
  cd ../mysql5.7-compose
  docker compose up -d
  sleep 10
  ```

  带来两个问题：

  - 用户白拉 MySQL 镜像、白等启动时间，拖慢上手流程
  - 文档让你启 MySQL，但实际配置又用 Derby，新人看了会困惑

  ## 修复

  中英文 README 同步更新（**不动代码、不动 compose 文件**）：

  - 把快速开始里的 MySQL 启动步骤和对应的 `sleep 10` 移除，让步骤跟配置实际所需的服务一致（etcd + Nacos + APISIX）
  - 加一段说明，解释 Nacos 用内嵌 Derby、`mysql5.7-compose` 目录保留作为生产级配置的参考，以及如何按需启用（启 MySQL + 取消 Nacos compose 里 MySQL  
  环境变量的注释）

  `mysql5.7-compose` 目录保留，希望用持久化存储的用户仍可使用。

  Closes #1087

  ---
