### PR TITLE
Fix/rolling logger

### DIFF
--- a/logger/README.md
+++ b/logger/README.md
@@ -40,10 +40,11 @@ logger.SetLoggerLevel("warn")
 
 #### output to file
 
-Add the file item under the logger option in the configuration file
+Set `appender: file` and add the file item under the logger option in the configuration file. When the sample is run from `logger/rolling`, the relative file name below is created as `logger/rolling/logs.log`. Use `appender: console,file` if you want the same log records to be written to both console and file.
 
 ```yaml
   logger:
+    appender: file
     file:
       name: logs.log
       max-size: 1

--- a/logger/README_zh.md
+++ b/logger/README_zh.md
@@ -40,10 +40,11 @@ logger.SetLoggerLevel("warn")
 
 #### 输出到文件
 
-在配置文件中的 logger 选项下添加 file 项
+在配置文件中的 logger 选项下设置 `appender: file` 并添加 file 项。从 `logger/rolling` 目录运行样例时，下面的相对文件名会生成到 `logger/rolling/logs.log`。如果希望同一批日志同时输出到控制台和文件，可使用 `appender: console,file`。
 
 ```yaml
   logger:
+    appender: file
     file:
       name: logs.log
       max-size: 1

--- a/logger/rolling/cmd/main.go
+++ b/logger/rolling/cmd/main.go
@@ -44,6 +44,7 @@ func main() {
 			logger.Info("hello dubbogo this is info log")
 			logger.Debug("hello dubbogo this is debug log")
 			logger.Warn("hello dubbogo this is warn log")
+			time.Sleep(time.Second * 1)
 		}
 	}
 }

--- a/logger/rolling/conf/dubbogo.yml
+++ b/logger/rolling/conf/dubbogo.yml
@@ -4,6 +4,7 @@ dubbo:
       name: tri
       port: 20000
   logger:
+    appender: file
     file:
       name: logs.log
       max-size: 1


### PR DESCRIPTION
## 变更内容

修复 `logger/rolling` 样例运行后未生成 `logs.log` 的问题。

主要修改：

- 在 `logger/rolling/conf/dubbogo.yml` 中增加 `appender: file`
  - dubbo-go logger 默认 `appender` 是 `console`
  - 仅配置 `logger.file` 不会自动启用文件输出
  - 显式设置 `appender: file` 后，日志会写入 `logs.log`

- 调整 `logger/rolling/cmd/main.go` 的日志输出频率
  - 每轮日志输出后增加 `time.Sleep(time.Second * 1)`
  - 与其他 logger 样例保持一致
  - 避免 3 秒内过快刷日志导致样例行为不直观

- 更新 `logger/README.md` 和 `logger/README_zh.md`
  - 说明文件输出需要配置 `appender: file`
  - 说明从 `logger/rolling` 目录运行时，`logs.log` 会生成在 `logger/rolling/logs.log`
  - 补充如需同时输出控制台和文件，可使用 `appender: console,file`

## 验证方式

在 PowerShell 中执行：

```powershell
cd logger/rolling
$env:DUBBO_GO_CONFIG_PATH = "./conf/dubbogo.yml"
go run ./cmd/main.go
Get-ChildItem .\logs.log
Get-Content .\logs.log -Tail 20
```


<img width="1226" height="725" alt="image" src="https://github.com/user-attachments/assets/343bd586-9cd0-4681-a301-6b9b9a7d6c46" />




issue https://github.com/apache/dubbo-go-samples/issues/1075