### PR TITLE
fix(metrics): improve probe sample shutdown behavior

### DIFF
--- a/metrics/probe/deploy/server-deployment.yml
+++ b/metrics/probe/deploy/server-deployment.yml
@@ -14,18 +14,10 @@ spec:
       labels:
         app: dubbo-go-probe-server
     spec:
-      terminationGracePeriodSeconds: 15
       containers:
         - name: server
           image: dubbo-go-probe-server:latest
           imagePullPolicy: IfNotPresent
-          resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
-            limits:
-              cpu: 500m
-              memory: 512Mi
           ports:
             - containerPort: 20000
               name: triple

--- a/metrics/probe/deploy/server-deployment.yml
+++ b/metrics/probe/deploy/server-deployment.yml
@@ -14,10 +14,18 @@ spec:
       labels:
         app: dubbo-go-probe-server
     spec:
+      terminationGracePeriodSeconds: 15
       containers:
         - name: server
           image: dubbo-go-probe-server:latest
           imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           ports:
             - containerPort: 20000
               name: triple

--- a/metrics/probe/go-server/cmd/main.go
+++ b/metrics/probe/go-server/cmd/main.go
@@ -44,12 +44,13 @@ import (
 )
 
 const (
-	triplePort         = 20000
-	probePort          = 22222
-	probeLivenessPath  = "/live"
-	probeReadinessPath = "/ready"
-	probeStartupPath   = "/startup"
-	warmupSeconds      = 15
+	triplePort           = 20000
+	probePort            = 22222
+	probeLivenessPath    = "/live"
+	probeReadinessPath   = "/ready"
+	probeStartupPath     = "/startup"
+	warmupSeconds        = 15
+	shutdownDrainSeconds = 6
 )
 
 type ProbeGreetServer struct{}
@@ -137,6 +138,6 @@ func main() {
 	probe.SetReady(false)
 	probe.SetStartupComplete(false)
 
-	// Wait for test to complete
-	time.Sleep(3 * time.Second)
+	// Wait longer than the Kubernetes readinessProbe period so NotReady can be observed.
+	time.Sleep(shutdownDrainSeconds * time.Second)
 }


### PR DESCRIPTION
**更改内容：**
metrics/probe/go-server/cmd/main.go
新增 shutdownDrainSeconds = 6
收到 SIGINT/SIGTERM 后，先把 probe 状态标记为 NotReady/NotStarted
然后等待 6 秒，让 Kubernetes 的 readinessProbe 有机会探测到 NotReady

metrics/probe/deploy/server-deployment.yml
新增 terminationGracePeriodSeconds: 15
新增容器资源配置：requests: cpu: 100m, memory: 128Mi
limits: cpu: 500m, memory: 512Mi

issue: https://github.com/apache/dubbo-go/issues/3204  metrics

**问题**
在按照  readme 多次测试的时候 docker k8s 可能会出现 还没等重新探测到 NotReady 就退出的情况

现在已经更改，结果与 readme 一样
<img width="1716" height="843" alt="image" src="https://github.com/user-attachments/assets/7a05a42e-9137-4e1f-bef2-1a4c0e51a2db" />

