### PR TITLE
fix(task/shop): 修复商城 demo 灰度路由相关的 2 个问题

### DIFF
--- a/task/shop/comment/server_v2/cmd/server.go
+++ b/task/shop/comment/server_v2/cmd/server.go
@@ -45,6 +45,7 @@ func (c *CommentProvider) GetComment(ctx context.Context, itemName *api.CommentR
 func main() {
 	ins, err := dubbo.NewInstance(
 		dubbo.WithName("shop-comment"),
+		dubbo.WithTag("gray"),
 		dubbo.WithRegistry(
 			registry.WithZookeeper(),
 			registry.WithAddress("127.0.0.1:2181"),

--- a/task/shop/detail/server_v2/cmd/server.go
+++ b/task/shop/detail/server_v2/cmd/server.go
@@ -66,6 +66,7 @@ func (d *DetailProvider) DeductStock(ctx context.Context, req *api.DeductStockRe
 func main() {
 	ins, err := dubbo.NewInstance(
 		dubbo.WithName("shop-detail"),
+		dubbo.WithTag("gray"),
 		dubbo.WithRegistry(
 			registry.WithZookeeper(),
 			registry.WithAddress("127.0.0.1:2181"),

--- a/task/shop/frontend/server_v1/server.go
+++ b/task/shop/frontend/server_v1/server.go
@@ -126,14 +126,7 @@ func (s *ShopServiceProvider) CheckItem(sku int64, username string) (*detailAPI.
 		Sku:      sku,
 		UserName: username,
 	}
-	// add tag
-	ctx := context.Background()
-	atm := map[string]string{
-		"dubbo.tag":       "gray",
-		"dubbo.force.tag": "true",
-	}
-	ctx = context.WithValue(ctx, constant.AttachmentKey, atm)
-	return s.detailService.GetItem(ctx, req)
+	return s.detailService.GetItem(context.Background(), req)
 }
 
 func (s *ShopServiceProvider) CheckItemGray(sku int64, username string) (*detailAPI.Item, error) {
@@ -141,7 +134,14 @@ func (s *ShopServiceProvider) CheckItemGray(sku int64, username string) (*detail
 		Sku:      sku,
 		UserName: username,
 	}
-	return s.detailService.GetItem(context.Background(), req)
+	// add tag for gray routing
+	ctx := context.Background()
+	atm := map[string]string{
+		"dubbo.tag":       "gray",
+		"dubbo.force.tag": "true",
+	}
+	ctx = context.WithValue(ctx, constant.AttachmentKey, atm)
+	return s.detailService.GetItem(ctx, req)
 }
 
 func (s *ShopServiceProvider) SubmitOrder(sku int64, count int, address, phone, receiver string) (*orderAPI.OrderResp, error) {

--- a/task/shop/frontend/server_v1/server.go
+++ b/task/shop/frontend/server_v1/server.go
@@ -137,8 +137,8 @@ func (s *ShopServiceProvider) CheckItemGray(sku int64, username string) (*detail
 	// add tag for gray routing
 	ctx := context.Background()
 	atm := map[string]string{
-		"dubbo.tag":       "gray",
-		"dubbo.force.tag": "true",
+		constant.Tagkey:      "gray",
+		constant.ForceUseTag: "true",
 	}
 	ctx = context.WithValue(ctx, constant.AttachmentKey, atm)
 	return s.detailService.GetItem(ctx, req)

--- a/task/shop/order/server_v2/cmd/server.go
+++ b/task/shop/order/server_v2/cmd/server.go
@@ -56,6 +56,7 @@ func (o *OrderProvider) SubmitOrder(ctx context.Context, req *api.OrderReq) (*ap
 func main() {
 	ins, err := dubbo.NewInstance(
 		dubbo.WithName("shop-order"),
+		dubbo.WithTag("gray"),
 		dubbo.WithRegistry(
 			registry.WithZookeeper(),
 			registry.WithAddress("127.0.0.1:2181"),


### PR DESCRIPTION
## 概述

修复 `task/shop` 商城 demo 中导致灰度路由（tag routing）无法工作的 2 个代码问题。

## 修复内容

### 修复 1：CheckItem/CheckItemGray 语义反转

`frontend/server_v1/server.go` 中 `CheckItem` 和 `CheckItemGray` 的实现与命名完全反了：
- `CheckItem` 内部附加了 `dubbo.tag=gray`（实际在做灰度路由）
- `CheckItemGray` 用 `context.Background()`（实际在做普通路由）

**修复：** 交换两个方法的实现，使命名与行为一致。

### 修复 2：v2 服务缺少灰度标签

v2 服务没有配置灰度标签，与 v1 在注册中心里无法区分，tag routing 无法命中灰度 provider。

**修复：** 为 comment-v2、detail-v2、order-v2 添加 `dubbo.WithTag("gray")`，与官方 `router/tag` 示例写法一致。

涉及文件：
- `comment/server_v2/cmd/server.go`
- `detail/server_v2/cmd/server.go`
- `order/server_v2/cmd/server.go`

## 测试验证

| 场景 | 预期 | 实际 | 状态 |
|---|---|---|---|
| `/login` 普通登录 | 返回 v1 数据 | 随机 v1/v2 | ⚠️ 框架问题 |
| `/grayLogin` 灰度登录 | 返回 v2 数据 | 500 | ⚠️ 框架问题 |
| `/timeoutLogin` 超时登录 | 显示超时提示 | ✅ | ✅ |
| `/order` 下单 | 下单成功 | ✅ | ✅ |
| `/userinfo` 用户信息 | 返回用户信息 | ✅ | ✅ |

## 备注

灰度路由的精确分流（`/login` 只命中 v1、`/grayLogin` 只命中 v2）依赖 dubbo-go 框架层面的修复：`application.tag` 在 service-discovery-registry 路径中未正确传播到 `dubbo.tag`，导致 tag router 无法区分 v1 和 v2 provider。

相关框架 issue：
- [apache/dubbo-go#3397](https://github.com/apache/dubbo-go/issues/3397) — Tag Router 端到端不可用
- [apache/dubbo-go#3398](https://github.com/apache/dubbo-go/issues/3398) — MetadataInfo.Tag 序列化问题

本 PR 仅修复 sample 代码问题，不涉及框架改动。框架修复后，本 PR 的修复将使灰度路由端到端可用。